### PR TITLE
CTAA-1344: Dismiss loading dialog allowing state loss

### DIFF
--- a/core/src/main/java/at/roteskreuz/stopcorona/skeleton/core/screens/base/fragment/BaseFragment.kt
+++ b/core/src/main/java/at/roteskreuz/stopcorona/skeleton/core/screens/base/fragment/BaseFragment.kt
@@ -175,7 +175,11 @@ abstract class BaseFragment(
     fun hideProgressDialog() {
         val currentDialog =
             childFragmentManager.findFragmentByTag(ProgressDialogFragment::class.java.name) as? ProgressDialogFragment
-        currentDialog?.dismiss()
+
+        currentDialog?.apply {
+            dismissAllowingStateLoss()
+            childFragmentManager.executePendingTransactions() // to prevent race condition
+        }
     }
 
     inline fun <reified T : DialogFragment> T.show(fragmentManager: FragmentManager = this@BaseFragment.childFragmentManager) {


### PR DESCRIPTION
## Changes
Prevent app from crashing with IllegalStateException when view is destroyed 

## Solved issues
- [Issue #1344](https://tasks.pxp-x.com/browse/CTAA-1344)