### PR TITLE
CTAA-1409 - Fixed randomly generated id on handshakes

### DIFF
--- a/app/src/main/java/at/roteskreuz/stopcorona/constants/Constants.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/constants/Constants.kt
@@ -162,11 +162,15 @@ object Constants {
     object Nearby {
 
         /**
-         * [RANDOM_IDENTIFICATION_MIN] defines the lower and [RANDOM_IDENTIFICATION_MAX] defines the
-         * upper bound of the randomly generated four digit long random identification number
-         * which is transmitted to all nearby devices
+         * [RANDOM_IDENTIFICATION_MIN] defines the lower bound of the randomly generated four digit
+         * long random identification number which is transmitted to all nearby devices.
          */
-        const val RANDOM_IDENTIFICATION_MIN = 1000
+        const val RANDOM_IDENTIFICATION_MIN = 0
+
+        /**
+         * [RANDOM_IDENTIFICATION_MAX] defines the upper bound of the randomly generated four digit
+         * long random identification number which is transmitted to all nearby devices.
+         */
         const val RANDOM_IDENTIFICATION_MAX = 9999
 
         /**

--- a/app/src/main/java/at/roteskreuz/stopcorona/di/ViewModelModule.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/di/ViewModelModule.kt
@@ -88,8 +88,7 @@ val viewModelModule = module {
         HandshakeViewModel(
             appDispatchers = get(),
             googleApiClientBuilder = get(),
-            nearbyRepository = get(),
-            handshakeCodewordRepository = get()
+            nearbyRepository = get()
         )
     }
 

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/HandshakeCodewordRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/HandshakeCodewordRepository.kt
@@ -44,7 +44,7 @@ class HandshakeCodewordRepositoryImpl(
     private val contextInteractor: ContextInteractor
 ) : HandshakeCodewordRepository {
 
-    override val identificationNumber: Int = Random.nextInt(from = RANDOM_IDENTIFICATION_MIN, until = RANDOM_IDENTIFICATION_MAX)
+    override val identificationNumber: Int = Random.nextInt(from = RANDOM_IDENTIFICATION_MIN, until = RANDOM_IDENTIFICATION_MAX + 1)
 
     override fun getCodeword(identification: Int): String {
         val value = zeroPrefixed(identification)

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/HandshakeCodewordRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/HandshakeCodewordRepository.kt
@@ -1,11 +1,13 @@
 package at.roteskreuz.stopcorona.model.repositories
 
+import androidx.annotation.IntRange
 import androidx.annotation.StringRes
 import at.roteskreuz.stopcorona.constants.Constants.Nearby.RANDOM_IDENTIFICATION_MAX
 import at.roteskreuz.stopcorona.constants.Constants.Nearby.RANDOM_IDENTIFICATION_MIN
 import at.roteskreuz.stopcorona.model.exceptions.SilentError
 import at.roteskreuz.stopcorona.model.repositories.other.ContextInteractor
 import timber.log.Timber
+import kotlin.math.abs
 import kotlin.random.Random
 
 /**
@@ -15,39 +17,38 @@ interface HandshakeCodewordRepository {
 
     /**
      * Random identification value which is sent to all nearby contacts.
-     * Has a value from 1000 to 9999
+     * Has a value from 0 to 9999.
      */
-    val identification: String
+    @get:IntRange(from = RANDOM_IDENTIFICATION_MIN.toLong(), to = RANDOM_IDENTIFICATION_MAX.toLong())
+    val identificationNumber: Int
 
     /**
      * Returns the related codeword for a random number.
      *
-     * [identification] the received random identification number with a value from 1000 to 9999.
+     * [identification] the received random identification number with a value from 0 to 9999.
      */
-    fun getCodeword(identification: String): String
+    fun getCodeword(
+        @IntRange(from = RANDOM_IDENTIFICATION_MIN.toLong(), to = RANDOM_IDENTIFICATION_MAX.toLong())
+        identification: Int
+    ): String
+
+    /**
+     * Convert number lower than 1000 to string with prefixed zeros to have 4 characters.
+     * Negative numbers are negated.
+     * If there is number greater than 9999, the result is last 4 characters of the string value.
+     */
+    fun zeroPrefixed(number: Int): String
 }
 
 class HandshakeCodewordRepositoryImpl(
     private val contextInteractor: ContextInteractor
 ) : HandshakeCodewordRepository {
 
-    override val identification: String = Random.nextInt(from = RANDOM_IDENTIFICATION_MIN, until = RANDOM_IDENTIFICATION_MAX).toString()
+    override val identificationNumber: Int = Random.nextInt(from = RANDOM_IDENTIFICATION_MIN, until = RANDOM_IDENTIFICATION_MAX)
 
-    override fun getCodeword(identification: String): String {
-        try {
-            Integer.parseInt(identification).apply {
-                if (this !in RANDOM_IDENTIFICATION_MIN..RANDOM_IDENTIFICATION_MAX) {
-                    Timber.e(SilentError("Identification number is invalid: $identification!"))
-                    return identification
-                }
-            }
-        } catch (exc: NumberFormatException) {
-            Timber.e(SilentError(exc))
-            return identification
-        }
-
-        val parts = listOf(identification.substring(0, 2), identification.substring(2))
-
+    override fun getCodeword(identification: Int): String {
+        val value = zeroPrefixed(identification)
+        val parts = arrayOf(value.substring(0, 2), value.substring(2))
         return with(getResourceId(parts[0])) {
             "${contextInteractor.getString(this)}${parts[1]}"
         }
@@ -56,5 +57,19 @@ class HandshakeCodewordRepositoryImpl(
     @StringRes
     private fun getResourceId(identifier: String): Int {
         return contextInteractor.resources.getIdentifier("handshake_code_$identifier", "string", contextInteractor.packageName)
+    }
+
+    override fun zeroPrefixed(number: Int): String {
+        val value = abs(number)
+        if (value < RANDOM_IDENTIFICATION_MIN ||
+            value > RANDOM_IDENTIFICATION_MAX ||
+            number < 0) {
+            Timber.e(SilentError("Invalid input number $number"))
+        }
+        return String.format("%04d", value).let {
+            if (it.length > 4) {
+                it.substring(it.length - 4)
+            } else it
+        }
     }
 }

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/handshake/HandshakeViewModel.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/handshake/HandshakeViewModel.kt
@@ -2,7 +2,6 @@ package at.roteskreuz.stopcorona.screens.handshake
 
 import androidx.fragment.app.FragmentActivity
 import at.roteskreuz.stopcorona.constants.Constants.Nearby.LOADING_INDICATOR_DELAY_MILLIS
-import at.roteskreuz.stopcorona.model.repositories.HandshakeCodewordRepository
 import at.roteskreuz.stopcorona.model.repositories.NearbyHandshakeState
 import at.roteskreuz.stopcorona.model.repositories.NearbyRepository
 import at.roteskreuz.stopcorona.model.repositories.NearbyResult
@@ -25,12 +24,11 @@ import java.util.concurrent.TimeUnit
 class HandshakeViewModel(
     appDispatchers: AppDispatchers,
     private val googleApiClientBuilder: GoogleApiClient.Builder,
-    private val nearbyRepository: NearbyRepository,
-    private val handshakeCodewordRepository: HandshakeCodewordRepository
+    private val nearbyRepository: NearbyRepository
 ) : ScopedViewModel(appDispatchers) {
 
     val personalIdentification
-        get() = handshakeCodewordRepository.getCodeword(nearbyRepository.personalIdentification)
+        get() = nearbyRepository.personalIdentificationCodeword
 
     private var messagesClient: MessagesClient? = null
     private var googleApiClient: GoogleApiClient? = null


### PR DESCRIPTION
## Changes
 
Fixed and algorithm for random generating id for handshake. Now it is able to use also numbers from 0 - 999.
 
## Solved issues
 
- [Issue #1409](https://tasks.pxp-x.com/browse/CTAA-1409)