### PR TITLE
CTAA-1384 - Add the new API call for uploading infections for contact…

### DIFF
--- a/app/src/main/java/at/roteskreuz/stopcorona/model/api/ApiDescription.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/api/ApiDescription.kt
@@ -1,9 +1,9 @@
 package at.roteskreuz.stopcorona.model.api
 
 import at.roteskreuz.stopcorona.model.entities.configuration.ApiConfigurationHolder
+import at.roteskreuz.stopcorona.model.entities.infection.info.ApiInfectionDataRequest
 import at.roteskreuz.stopcorona.model.entities.infection.info.ApiInfectionInfoRequest
 import at.roteskreuz.stopcorona.model.entities.infection.message.ApiInfectionMessages
-import at.roteskreuz.stopcorona.model.entities.tan.ApiRequestTan
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PUT
@@ -22,4 +22,7 @@ interface ApiDescription {
 
     @PUT("infection-info")
     suspend fun infectionInfo(@Body infectionInfoRequest: ApiInfectionInfoRequest)
+
+    @PUT("publish")
+    suspend fun publish(@Body infectionDataRequest: ApiInfectionDataRequest)
 }

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/entities/infection/info/ApiInfectionDataRequest.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/entities/infection/info/ApiInfectionDataRequest.kt
@@ -3,7 +3,7 @@ package at.roteskreuz.stopcorona.model.entities.infection.info
 import com.squareup.moshi.JsonClass
 
 /**
- * Describes infection info about user with data from the Exposure SDK.
+ * Describes infection info about user with data gathered from the Exposure SDK.
  */
 @JsonClass(generateAdapter = true)
 data class ApiInfectionDataRequest(

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/entities/infection/info/ApiInfectionDataRequest.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/entities/infection/info/ApiInfectionDataRequest.kt
@@ -1,0 +1,32 @@
+package at.roteskreuz.stopcorona.model.entities.infection.info
+
+import com.squareup.moshi.JsonClass
+
+/**
+ * Describes infection info about user with data from the Exposure SDK.
+ */
+@JsonClass(generateAdapter = true)
+data class ApiInfectionDataRequest(
+    val temporaryTracingKeys: List<ApiTemporaryTracingKey>,
+    val regions: List<String>,
+    val appPackageName: String,
+    val platform: String,
+    val diagnosisType: WarningType,
+    val verificationAuthorityName: String,
+    val verificationPayload: ApiVerificationPayload
+)
+
+@JsonClass(generateAdapter = true)
+data class ApiTemporaryTracingKey(
+    val key: String,
+    val password: String,
+    val intervalNumber: Long,
+    val intervalCount: Int,
+    val transmissionRisk: Int
+)
+
+@JsonClass(generateAdapter = true)
+data class ApiVerificationPayload(
+    val uuid: String,
+    val authorization: String
+)


### PR DESCRIPTION
## Changes

Implement new API call for uploading infection info for contacts gathered through Exposure SDK.

## Solved issues

- [Issue #1384](https://tasks.pxp-x.com/browse/CTAA-1384)
