### PR TITLE
CTAA-1382 - Fixed unregistration functionality

### DIFF
--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/ExposureNotificationRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/ExposureNotificationRepository.kt
@@ -1,6 +1,5 @@
 package at.roteskreuz.stopcorona.model.repositories
 
-import android.app.Activity
 import at.roteskreuz.stopcorona.model.exceptions.SilentError
 import at.roteskreuz.stopcorona.skeleton.core.model.helpers.AppDispatchers
 import at.roteskreuz.stopcorona.skeleton.core.model.helpers.State
@@ -123,7 +122,7 @@ class ExposureNotificationRepositoryImpl(
 
     override fun onExposureNotificationRegistrationResolutionResultOk() {
         registeringWithFrameworkState.loading()
-        exposureNotificationClient.start()
+        exposureNotificationClient.stop()
             .addOnSuccessListener {
                 refreshExposureNotificationAppRegisteredState()
                 registeringWithFrameworkState.idle()


### PR DESCRIPTION
## Changes

Fixed issue when switch for disabling exposure notification framework was not working. (called the start method instead of stop 🤦 )

## Solved issues

- [Issue #1382](https://tasks.pxp-x.com/browse/CTAA-1382) - updated
