### PR TITLE
CTAA-1642 - Remove check for support of Le2MPhy (which is available f…

### DIFF
--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/BluetoothRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/BluetoothRepository.kt
@@ -1,7 +1,6 @@
 package at.roteskreuz.stopcorona.model.repositories
 
 import android.bluetooth.BluetoothAdapter
-import android.os.Build
 import at.roteskreuz.stopcorona.model.managers.BluetoothManager
 import at.roteskreuz.stopcorona.utils.NonNullableBehaviorSubject
 import io.reactivex.Observable
@@ -12,7 +11,7 @@ import io.reactivex.Observable
 interface BluetoothRepository {
 
     /**
-     * Return true if bluetooth adapter exists and is supported by exposure notification framework.
+     * Return true if bluetooth adapter exists.
      */
     val bluetoothSupported: Boolean
 
@@ -41,11 +40,7 @@ class BluetoothRepositoryImpl(
         bluetoothAdapter?.isEnabled == true
     )
     override val bluetoothSupported: Boolean
-        get() = bluetoothAdapter != null && if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            bluetoothAdapter.isLe2MPhySupported
-        } else {
-            true
-        }
+        get() = bluetoothAdapter != null
 
     override val bluetoothEnabled: Boolean
         get() = (bluetoothSupported && bluetoothAdapter?.isEnabled == true).also {


### PR DESCRIPTION
## Changes

Remove the requirement for Le2MPhy because it's available only from Bluetooth 5.0.

The device should have at least Bluetooth 4.0 because we are currently requiring the devices to have BLE support in manifest:
<uses-feature
        android:name="android.hardware.bluetooth_le"
        android:required="true" />


