### PR TITLE
Backport "build number from CI" from v1.2.2

### DIFF
--- a/gradle/base.gradle
+++ b/gradle/base.gradle
@@ -1,6 +1,6 @@
 ext.getBuildCode = {
-    if (System.getenv('CI_PIPELINE_IID') != null) {
-        return System.getenv('CI_PIPELINE_IID').trim().toInteger()
+    if (System.getenv('BUILD_BUILDID') != null) {
+        return System.getenv('BUILD_BUILDID').trim().toInteger()
     } else {
         return 12
     }


### PR DESCRIPTION
## Changes

Backported from v1.2.2: Use build number from CI

## Solved issues

- no ticket
