### PR TITLE
CTAA-1628: Fixed order of changelog-dialog and starting of the exposu…

### DIFF
--- a/app/src/main/java/at/roteskreuz/stopcorona/di/ViewModelModule.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/di/ViewModelModule.kt
@@ -69,7 +69,6 @@ val viewModelModule = module {
             dashboardRepository = get(),
             infectionMessengerRepository = get(),
             quarantineRepository = get(),
-            configurationRepository = get(),
             databaseCleanupManager = get(),
             changelogManager = get(),
             exposureNotificationManager = get()

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/managers/ChangelogManager.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/managers/ChangelogManager.kt
@@ -35,7 +35,7 @@ interface ChangelogManager {
     /**
      * Marks the changelog as seen.
      */
-    fun flagChangelogAsSeen()
+    fun markChangelogAsSeen()
 }
 
 class ChangelogManagerImpl(
@@ -85,7 +85,7 @@ class ChangelogManagerImpl(
         }
     }
 
-    override fun flagChangelogAsSeen() {
+    override fun markChangelogAsSeen() {
         lastSeenChangelogId = changelog.id
     }
 

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardFragment.kt
@@ -220,18 +220,11 @@ class DashboardFragment : BaseFragment(R.layout.fragment_dashboard) {
                 controller.someoneHasRecoveredHealthStatus = it
             }
 
-        disposables += viewModel.observeExposureNotificationPhase()
+        disposables += viewModel.observeExposureSDKReadyToStart()
             .observeOnMainThread()
-            .subscribe { phase ->
-                controller.exposureNotificationPhase = phase
-                when (phase) {
-                    is FrameworkError.Critical.ResolutionRequired -> {
-                        phase.exception.status.startResolutionForResult(
-                            requireActivity(),
-                            REQUEST_CODE_EXPOSURE_NOTIFICATION_RESOLUTION_REQUIRED
-                        )
-                    }
-                    is FrameworkError.Critical.Unknown -> handleBaseCoronaErrors(phase.exception)
+            .subscribe {
+                if (it) {
+                    startExposureSDK()
                 }
             }
 
@@ -284,5 +277,22 @@ class DashboardFragment : BaseFragment(R.layout.fragment_dashboard) {
                 }
             }
         }
+    }
+
+    private fun startExposureSDK() {
+        disposables += viewModel.observeExposureNotificationPhase()
+            .observeOnMainThread()
+            .subscribe { phase ->
+                controller.exposureNotificationPhase = phase
+                when (phase) {
+                    is FrameworkError.Critical.ResolutionRequired -> {
+                        phase.exception.status.startResolutionForResult(
+                            requireActivity(),
+                            REQUEST_CODE_EXPOSURE_NOTIFICATION_RESOLUTION_REQUIRED
+                        )
+                    }
+                    is FrameworkError.Critical.Unknown -> handleBaseCoronaErrors(phase.exception)
+                }
+            }
     }
 }

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardFragment.kt
@@ -222,8 +222,8 @@ class DashboardFragment : BaseFragment(R.layout.fragment_dashboard) {
 
         disposables += viewModel.observeExposureSDKReadyToStart()
             .observeOnMainThread()
-            .subscribe {
-                if (it) {
+            .subscribe { readyToStart ->
+                if (readyToStart) {
                     startExposureSDK()
                 }
             }

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardViewModel.kt
@@ -22,16 +22,10 @@ class DashboardViewModel(
     private val dashboardRepository: DashboardRepository,
     private val infectionMessengerRepository: InfectionMessengerRepository,
     private val quarantineRepository: QuarantineRepository,
-    private val configurationRepository: ConfigurationRepository,
     private val databaseCleanupManager: DatabaseCleanupManager,
     private val changelogManager: ChangelogManager,
     private val exposureNotificationManager: ExposureNotificationManager
 ) : ScopedViewModel(appDispatchers) {
-
-    companion object {
-        const val DEFAULT_RED_WARNING_QUARANTINE = 336 // hours
-        const val DEFAULT_YELLOW_WARNING_QUARANTINE = 168 // hours
-    }
 
     private var wasExposureFrameworkAutomaticallyEnabledOnFirstStart: Boolean
         get() = dashboardRepository.exposureFrameworkEnabledOnFirstStart
@@ -152,7 +146,13 @@ class DashboardViewModel(
         exposureNotificationManager.refreshPrerequisitesErrorStatement(ignoreErrors)
     }
 
-    fun unseenChangelogForVersionAvailable(version: String) = changelogManager.unseenChangelogForVersionAvailable(version)
+    fun unseenChangelogForVersionAvailable(version: String): Boolean {
+        return changelogManager.unseenChangelogForVersionAvailable(version)
+    }
+
+    fun observeExposureSDKReadyToStart(): Observable<Boolean> {
+        return changelogManager.observeExposureSDKReadyToStart().distinctUntilChanged()
+    }
 }
 
 /**

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/changelog/ChangelogFragment.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/changelog/ChangelogFragment.kt
@@ -57,7 +57,7 @@ class ChangelogFragment : BottomSheetDialogFragment() {
     override fun onDismiss(dialog: DialogInterface) {
         super.onDismiss(dialog)
 
-        viewModel.flagChangelogAsSeen()
+        viewModel.markChangelogAsSeen()
     }
 }
 

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/changelog/ChangelogFragment.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/changelog/ChangelogFragment.kt
@@ -1,5 +1,6 @@
 package at.roteskreuz.stopcorona.screens.dashboard.changelog
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -51,6 +52,12 @@ class ChangelogFragment : BottomSheetDialogFragment() {
         viewModel.getChangelogForVersion(VERSION_NAME)?.let {
             controller.setData(it)
         }
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+
+        viewModel.flagChangelogAsSeen()
     }
 }
 

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/changelog/ChangelogViewModel.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/changelog/ChangelogViewModel.kt
@@ -14,7 +14,7 @@ class ChangelogViewModel(
         return changelogManager.getChangelogForVersion(version)
     }
 
-    fun flagChangelogAsSeen() {
-        changelogManager.flagChangelogAsSeen()
+    fun markChangelogAsSeen() {
+        changelogManager.markChangelogAsSeen()
     }
 }

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/changelog/ChangelogViewModel.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/changelog/ChangelogViewModel.kt
@@ -1,5 +1,6 @@
 package at.roteskreuz.stopcorona.screens.dashboard.changelog
 
+import at.roteskreuz.stopcorona.model.managers.Changelog
 import at.roteskreuz.stopcorona.model.managers.ChangelogManager
 import at.roteskreuz.stopcorona.skeleton.core.model.helpers.AppDispatchers
 import at.roteskreuz.stopcorona.skeleton.core.screens.base.viewmodel.ScopedViewModel
@@ -9,5 +10,11 @@ class ChangelogViewModel(
     private val changelogManager: ChangelogManager
 ) : ScopedViewModel(appDispatchers) {
 
-    fun getChangelogForVersion(version: String) = changelogManager.getChangelogForVersion(version)
+    fun getChangelogForVersion(version: String): Changelog? {
+        return changelogManager.getChangelogForVersion(version)
+    }
+
+    fun flagChangelogAsSeen() {
+        changelogManager.flagChangelogAsSeen()
+    }
 }


### PR DESCRIPTION
## Changes

Fixed order of changelog-sheet and exposure SDK permission dialog:
SDK permission is not overlaying the changelog-sheet anymore, started after the sheet is dismissed.

## Solved issues

- [Issue #1628](https://tasks.pxp-x.com/browse/CTAA-1628)
