### PR TITLE
Fix/disable green warning special case

### DIFF
--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/InfectionMessengerRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/InfectionMessengerRepository.kt
@@ -318,10 +318,17 @@ class InfectionMessengerRepositoryImpl(
         withContext(coroutineContext) {
             try {
                 val warningType = quarantineRepository.getCurrentWarningType()
+                val fetchDaily = when (warningType) {
+                    WarningType.GREEN, // No special handling of WarningType.GREEN as the optimization is currently broken. See comment on `else` branch.
+                    WarningType.YELLOW, WarningType.RED -> false
+                    // This branch is disabled (i.e. will never be reached). It is an optimized handling of WarningType.GREEN which is currently broken
+                    // due to a bug in Google's EN framework which drops broadcasts if no keys matched at all.
+                    else -> true
+                }
                 val token = UUID.randomUUID().toString()
                 val index = apiInteractor.getIndexOfDiagnosisKeysArchives()
                 val fullBatchParts = fetchFullBatchDiagnosisKeys(index.fullBatchForWarningType(warningType))
-                val dailyBatchesParts = fetchDailyBatchesDiagnosisKeys(index.dailyBatches)
+                val dailyBatchesParts = if (fetchDaily) fetchDailyBatchesDiagnosisKeys(index.dailyBatches) else emptyList()
 
                 val fullSession = DbFullSession(
                     session = DbSession(

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/InfectionMessengerRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/InfectionMessengerRepository.kt
@@ -224,6 +224,7 @@ class InfectionMessengerRepositoryImpl(
         val summary = exposureNotificationRepository.determineRiskWithoutInformingUser(token)
 
         when (currentWarningType) {
+            WarningType.GREEN, // No special handling of WarningType.GREEN as the optimization is currently broken. See comment on `else` branch.
             WarningType.YELLOW, WarningType.RED -> {
                 if (summary.summationRiskScore < configuration.dailyRiskThreshold) {
                     quarantineRepository.revokeLastRedContactDate()
@@ -249,7 +250,9 @@ class InfectionMessengerRepositoryImpl(
                     return true // Processing done
                 }
             }
-            WarningType.GREEN -> {
+            // This branch is disabled (i.e. will never be reached). It is an optimized handling of WarningType.GREEN which is currently broken
+            // due to a bug in Google's EN framework which drops broadcasts if no keys matched at all.
+            else -> {
                 //we are above risc for the last days!!!
                 if (summary.summationRiskScore >= configuration.dailyRiskThreshold) {
 
@@ -361,8 +364,11 @@ class InfectionMessengerRepositoryImpl(
 
     private fun ApiIndexOfDiagnosisKeysArchives.fullBatchForWarningType(warningType: WarningType): ApiDiagnosisKeysBatch {
         return when (warningType) {
+            WarningType.GREEN, // No special handling of WarningType.GREEN as the optimization is currently broken. See comment on `else` branch.
             WarningType.YELLOW, WarningType.RED -> full14DaysBatch
-            WarningType.GREEN -> full07DaysBatch
+            // This branch is disabled (i.e. will never be reached). It is an optimized handling of WarningType.GREEN which is currently broken
+            // due to a bug in Google's EN framework which drops broadcasts if no keys matched at all.
+            else -> full07DaysBatch
         }
     }
 


### PR DESCRIPTION
## Changes

- Disable special casing the GREEN warning case as a new way of dealing with the situation.

The special case we implemented to avoid Google's notification which is sent for calls to getExposureNotification() is currently not possible as it relies on chaining the provideDiagnosisKeys() calls and this chaining is broken due to missing broadcasts.

This PR disables the special case, knowingly accepting that the user gets a notification every time he has a relevant amount of exposures accumulated over the last 14 days.


