### PR TITLE
Task/ctaa 1683 notification for no risk

### DIFF
--- a/app/src/main/java/at/roteskreuz/stopcorona/di/RepositoryModule.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/di/RepositoryModule.kt
@@ -50,7 +50,8 @@ val repositoryModule = module {
             quarantineRepository = get(),
             workManager = get(),
             exposureNotificationRepository = get(),
-            configurationRepository = get()
+            configurationRepository = get(),
+            notificationsRepository = get()
         )
     }
 

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/InfectionMessengerRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/InfectionMessengerRepository.kt
@@ -95,7 +95,8 @@ class InfectionMessengerRepositoryImpl(
     private val quarantineRepository: QuarantineRepository,
     private val workManager: WorkManager,
     private val exposureNotificationRepository: ExposureNotificationRepository,
-    private val configurationRepository: ConfigurationRepository
+    private val configurationRepository: ConfigurationRepository,
+    val notificationsRepository: NotificationsRepository
 ) : InfectionMessengerRepository,
     CoroutineScope {
 
@@ -236,6 +237,10 @@ class InfectionMessengerRepositoryImpl(
                     // quarantine end tile is triggered in the ui
                     if (dates.firstRedDay == null) quarantineRepository.revokeLastRedContactDate()
                     if (dates.firstYellowDay == null) quarantineRepository.revokeLastYellowContactDate()
+
+                    if (currentWarningType == WarningType.GREEN && dates.noDates()){
+                        notificationsRepository.displayNotificationForLowRisc()
+                    }
 
                     return true // Processing done
                 }

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/NotificationsRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/NotificationsRepository.kt
@@ -68,6 +68,12 @@ interface NotificationsRepository {
      * Hide notification by [id].
      */
     fun hideNotification(id: Int)
+
+    /**
+     * Display a notification, informing the user that the combined risk of the exposures from
+     * the Exposure Notifications Framework was too low to qualify for a quarantine.
+     */
+    fun displayNotificationForLowRisc()
 }
 
 class NotificationsRepositoryImpl(
@@ -199,6 +205,21 @@ class NotificationsRepositoryImpl(
 
     override fun hideNotification(id: Int) {
         notificationManager.cancel(id)
+    }
+
+    override fun displayNotificationForLowRisc() {
+        val title = context.string(R.string.local_notification_low_risk_title)
+        val message = context.string(R.string.local_notification_low_risk_message)
+
+        buildNotification(
+            title = title,
+            message = message,
+            pendingIntent = buildPendingIntentWithActivityStack {
+                addNextIntent(context.getDashboardActivityIntent().addFlags(firstActivityFlags))
+            },
+            channelId = NotificationChannels.CHANNEL_INFECTION_MESSAGE,
+            ongoing = true
+        ).show()
     }
 
     private fun buildNotification(

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/NotificationsRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/NotificationsRepository.kt
@@ -218,7 +218,7 @@ class NotificationsRepositoryImpl(
                 addNextIntent(context.getDashboardActivityIntent().addFlags(firstActivityFlags))
             },
             channelId = NotificationChannels.CHANNEL_INFECTION_MESSAGE,
-            ongoing = true
+            ongoing = false
         ).show()
     }
 

--- a/app/src/main/java/at/roteskreuz/stopcorona/utils/ExposureNotficationExtensions.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/utils/ExposureNotficationExtensions.kt
@@ -76,7 +76,11 @@ fun List<ExposureInformation>.extractLatestRedAndYellowContactDate(dailyRiskThre
 data class ExposureDates(
     val firstRedDay: Instant?,
     val firstYellowDay: Instant?
-)
+) {
+    fun noDates(): Boolean {
+        return firstRedDay == null && firstYellowDay == null
+    }
+}
 
 data class InfectionMessageDay(
     val day: Instant,

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -103,6 +103,8 @@
 	<string name="main_exposure_error_bluetooth_off_action">Aktivieren</string>
 	<string name="main_exposure_error_action">Versuchen Sie es noch einmal</string>
 	<string name="main_reporting_disable_btn">Aktivieren Sie den automatischen Handshake für diese Funktion.</string>
+	<string name="local_notification_low_risk_title">Auswertung: Kein COVID-19 Ansteckungsrisiko</string>
+	<string name="local_notification_low_risk_message">Die Auswertung der möglichen Begegnungen mit COVID-19-Infizierten ergabt kein relevantes Ansteckungsrisiko auf Grund der hinterlegten Dauer bzw. Abstands der möglichen Begegnungen. Bitte achten Sie weiterhin auf die geltenden Hygiene-Empfehlungen.</string>
 
 	<!-- Update Information -->
 	<string name="mandatory_update_title">Aktuelle Version herunterladen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,6 +103,8 @@
 	<string name="main_exposure_error_bluetooth_off_action">Activate</string>
 	<string name="main_exposure_error_action">Try again</string>
 	<string name="main_reporting_disable_btn">Activate the automatic handshake for this function.</string>
+	<string name="local_notification_low_risk_title">No COVID-19 infection risk </string>
+	<string name="local_notification_low_risk_message">The evaluation of the possible encounter with COVID-19 infected persons did not reveal any relevant risk of infection due to the stored duration or distance of the possible encounter. Please continue to observe the applicable hygiene recommendations.</string>
 
 	<!-- Update Information -->
 	<string name="mandatory_update_title">Download the current version</string>


### PR DESCRIPTION
## Changes

Notification when there is not enough risc to become "YELLOW" or "RED" but the EN framework already notified the user

## Solved issues

- [Issue #1683](https://tasks.pxp-x.com/browse/CTAA-1683)
