### PR TITLE
Fix/rename infection messenger repository

### DIFF
--- a/app/src/main/java/at/roteskreuz/stopcorona/di/ContextDependentModule.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/di/ContextDependentModule.kt
@@ -49,7 +49,7 @@ internal val contextDependentModule = module {
             processLifecycleOwner = ProcessLifecycleOwner.get(),
             configurationRepository = get(),
             dataPrivacyRepository = get(),
-            infectionMessengerRepository = get()
+            diagnosisKeysRepository = get()
         )
     }
 

--- a/app/src/main/java/at/roteskreuz/stopcorona/di/RepositoryModule.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/di/RepositoryModule.kt
@@ -40,8 +40,8 @@ val repositoryModule = module {
     }
 
 
-    single<InfectionMessengerRepository> {
-        InfectionMessengerRepositoryImpl(
+    single<DiagnosisKeysRepository> {
+        DiagnosisKeysRepositoryImpl(
             appDispatchers = get(),
             apiInteractor = get(),
             sessionDao = get(),

--- a/app/src/main/java/at/roteskreuz/stopcorona/di/ScopeModule.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/di/ScopeModule.kt
@@ -19,7 +19,7 @@ val scopeModule = module {
             apiInteractor = get(),
             quarantineRepository = get(),
             contextInteractor = get(),
-            infectionMessengerRepository = get(),
+            diagnosisKeysRepository = get(),
             configurationRepository = get()
         )
     }

--- a/app/src/main/java/at/roteskreuz/stopcorona/di/ViewModelModule.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/di/ViewModelModule.kt
@@ -33,7 +33,7 @@ val viewModelModule = module {
     viewModel {
         DebugViewModel(
             appDispatchers = get(),
-            infectionMessengerRepository = get(),
+            diagnosisKeysRepository = get(),
             notificationsRepository = get(),
             quarantineRepository = get(),
             configurationRepository = get()
@@ -57,7 +57,7 @@ val viewModelModule = module {
             contextInteractor = get(),
             exposureNotificationRepository = get(),
             exposureNotificationClient = get(),
-            infectionMessengerRepository = get(),
+            diagnosisKeysRepository = get(),
             filesRepository = get(),
             configurationRepository = get()
         )
@@ -67,7 +67,7 @@ val viewModelModule = module {
         DashboardViewModel(
             appDispatchers = get(),
             dashboardRepository = get(),
-            infectionMessengerRepository = get(),
+            diagnosisKeysRepository = get(),
             quarantineRepository = get(),
             databaseCleanupManager = get(),
             changelogManager = get(),

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/db/dao/TemporaryExposureKeysDao.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/db/dao/TemporaryExposureKeysDao.kt
@@ -40,7 +40,7 @@ abstract class TemporaryExposureKeysDao {
     }
 
     @Query("DELETE FROM sent_temporary_exposure_keys WHERE messageType = :messageType AND rollingStartIntervalNumber < :olderThan")
-    abstract suspend fun removeSentInfectionMessagesOlderThan(
+    abstract suspend fun removeSentTemporarelyExposureKeysOlderThan(
         messageType: MessageType,
         olderThan: Int
     )

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/managers/DatabaseCleanupManager.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/managers/DatabaseCleanupManager.kt
@@ -52,7 +52,7 @@ class DatabaseCleanupManagerImpl(
                 .minusDays(NUMBER_OF_DAYS_THE_GREEN_KEYS_ARE_KEPT)
                 .startOfTheUtcDay()
                 .toRollingStartIntervalNumber()
-            temporaryExposureKeysDao.removeSentInfectionMessagesOlderThan(
+            temporaryExposureKeysDao.removeSentTemporarelyExposureKeysOlderThan(
                 MessageType.Revoke.Suspicion,
                 thresholdRevokedMessagesAsRollingStart
             )
@@ -66,7 +66,7 @@ class DatabaseCleanupManagerImpl(
                     .minusHours(yellowWarningQuarantine + 1)
                     .toRollingStartIntervalNumber()
 
-                temporaryExposureKeysDao.removeSentInfectionMessagesOlderThan(
+                temporaryExposureKeysDao.removeSentTemporarelyExposureKeysOlderThan(
                     MessageType.InfectionLevel.Yellow,
                     thresholdYellowMessageAsRollingStart
                 )
@@ -81,7 +81,7 @@ class DatabaseCleanupManagerImpl(
                     .minusHours(redWarningQuarantine + 1)
                     .toRollingStartIntervalNumber()
 
-                temporaryExposureKeysDao.removeSentInfectionMessagesOlderThan(
+                temporaryExposureKeysDao.removeSentTemporarelyExposureKeysOlderThan(
                     MessageType.InfectionLevel.Red,
                     thresholdRedMessagesAsRollingStart
                 )

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/DiagnosisKeysRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/DiagnosisKeysRepository.kt
@@ -37,9 +37,9 @@ import java.util.UUID
 import kotlin.coroutines.CoroutineContext
 
 /**
- * Repository for managing infection messages.
+ * Repository for managing diagnosis keys and infection related user status
  */
-interface InfectionMessengerRepository {
+interface DiagnosisKeysRepository {
 
     /**
      * Store to DB the sent temporary exposure keys.
@@ -91,7 +91,7 @@ interface InfectionMessengerRepository {
     suspend fun processKeysBasedOnToken(token: String)
 }
 
-class InfectionMessengerRepositoryImpl(
+class DiagnosisKeysRepositoryImpl(
     private val appDispatchers: AppDispatchers,
     private val apiInteractor: ApiInteractor,
     private val sessionDao: SessionDao,
@@ -102,7 +102,7 @@ class InfectionMessengerRepositoryImpl(
     private val exposureNotificationRepository: ExposureNotificationRepository,
     private val configurationRepository: ConfigurationRepository,
     val notificationsRepository: NotificationsRepository
-) : InfectionMessengerRepository,
+) : DiagnosisKeysRepository,
     CoroutineScope {
 
     companion object {

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/other/OfflineSyncer.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/other/OfflineSyncer.kt
@@ -13,7 +13,7 @@ import at.roteskreuz.stopcorona.model.exceptions.DataPopulationFailedException
 import at.roteskreuz.stopcorona.model.exceptions.SilentError
 import at.roteskreuz.stopcorona.model.repositories.ConfigurationRepository
 import at.roteskreuz.stopcorona.model.repositories.DataPrivacyRepository
-import at.roteskreuz.stopcorona.model.repositories.InfectionMessengerRepository
+import at.roteskreuz.stopcorona.model.repositories.DiagnosisKeysRepository
 import at.roteskreuz.stopcorona.screens.mandatory_update.startMandatoryUpdateFragment
 import at.roteskreuz.stopcorona.screens.routing.RouterActivity
 import at.roteskreuz.stopcorona.skeleton.core.model.helpers.AppDispatchers
@@ -45,7 +45,7 @@ class OfflineSyncerImpl(
     private val processLifecycleOwner: LifecycleOwner,
     private val configurationRepository: ConfigurationRepository,
     private val dataPrivacyRepository: DataPrivacyRepository,
-    private val infectionMessengerRepository: InfectionMessengerRepository
+    private val diagnosisKeysRepository: DiagnosisKeysRepository
 ) : OfflineSyncer {
 
     companion object {
@@ -121,7 +121,7 @@ class OfflineSyncerImpl(
     private fun CoroutineScope.populateDatabasesAsync(): List<Deferred<Unit>> {
         return listOf(
             async { runPopulationAndLogExceptions { configurationRepository.populateConfigurationIfEmpty() } },
-            async { runPopulationAndLogExceptions { infectionMessengerRepository.enqueueNextExposureMatching() } }
+            async { runPopulationAndLogExceptions { diagnosisKeysRepository.enqueueNextExposureMatching() } }
         )
     }
 
@@ -136,7 +136,7 @@ class OfflineSyncerImpl(
             }
             // read all infection messages
             runFetcherIfNeeded(PREF_LAST_FETCH_INFECTION_MESSAGES) {
-                infectionMessengerRepository.fetchAndForwardNewDiagnosisKeysToTheExposureNotificationFramework()
+                diagnosisKeysRepository.fetchAndForwardNewDiagnosisKeysToTheExposureNotificationFramework()
             }
         }
     }

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/workers/ExposureMatchingWorker.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/workers/ExposureMatchingWorker.kt
@@ -3,7 +3,7 @@ package at.roteskreuz.stopcorona.model.workers
 import android.content.Context
 import androidx.work.*
 import at.roteskreuz.stopcorona.model.exceptions.SilentError
-import at.roteskreuz.stopcorona.model.repositories.InfectionMessengerRepository
+import at.roteskreuz.stopcorona.model.repositories.DiagnosisKeysRepository
 import at.roteskreuz.stopcorona.utils.minus
 import org.koin.standalone.KoinComponent
 import org.koin.standalone.inject
@@ -66,11 +66,11 @@ class ExposureMatchingWorker(
     }
 
     private val workManager: WorkManager by inject()
-    private val infectionMessengerRepository: InfectionMessengerRepository by inject()
+    private val diagnosisKeysRepository: DiagnosisKeysRepository by inject()
 
     override suspend fun doWork(): Result {
         try {
-            infectionMessengerRepository.fetchAndForwardNewDiagnosisKeysToTheExposureNotificationFramework()
+            diagnosisKeysRepository.fetchAndForwardNewDiagnosisKeysToTheExposureNotificationFramework()
         } catch (ex: Exception){
             //we agreed to silently fail in case of errors here
             Timber.e(SilentError(ex))

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/workers/ProcessDiagnosisKeysWorker.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/workers/ProcessDiagnosisKeysWorker.kt
@@ -3,7 +3,7 @@ package at.roteskreuz.stopcorona.model.workers
 import android.content.Context
 import androidx.work.*
 import at.roteskreuz.stopcorona.model.exceptions.SilentError
-import at.roteskreuz.stopcorona.model.repositories.InfectionMessengerRepository
+import at.roteskreuz.stopcorona.model.repositories.DiagnosisKeysRepository
 import org.koin.standalone.KoinComponent
 import org.koin.standalone.inject
 import timber.log.Timber
@@ -47,13 +47,13 @@ class ProcessDiagnosisKeysWorker(
         }
     }
 
-    private val infectionMessengerRepository: InfectionMessengerRepository by inject()
+    private val diagnosisKeysRepository: DiagnosisKeysRepository by inject()
 
     override suspend fun doWork(): Result {
         val token = inputData.getString(ARGUMENT_TOKEN)
         try {
             token?.let {
-                infectionMessengerRepository.processKeysBasedOnToken(token)
+                diagnosisKeysRepository.processKeysBasedOnToken(token)
                 return@doWork Result.success()
             }
             Timber.e(SilentError(IllegalArgumentException("No Token was provided, no work can be done")))

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/base/CoronaBaseActivity.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/base/CoronaBaseActivity.kt
@@ -62,12 +62,12 @@ open class CoronaBaseActivity(@LayoutRes layout: Int = R.layout.framelayout) : B
                 Toast.makeText(this, quarantineStatus.toString(), Toast.LENGTH_LONG).show()
                 true
             }
-            R.id.debugMenuInfectionMessagesOutgoingRed -> {
-                debugViewModel.addOutgoingMessageRed()
+            R.id.debugMenuReportMedicalConfirmation -> {
+                debugViewModel.reportMedicalConfirmation()
                 true
             }
-            R.id.debugMenuInfectionMessagesOutgoingYellow -> {
-                debugViewModel.addOutgoingMessageYellow()
+            R.id.debugMenuReportPositiveSelfDiagnose -> {
+                debugViewModel.reportPositiveSelfDiagnose()
                 true
             }
             R.id.debugExposureNotifications -> {

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/base/DebugViewModel.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/base/DebugViewModel.kt
@@ -53,14 +53,14 @@ class DebugViewModel(
         return quarantineRepository.observeQuarantineState().blockingFirst()
     }
 
-    fun addOutgoingMessageRed() {
+    fun reportMedicalConfirmation() {
         launch {
             // Only set the sickness report date. Does not store keys in the saved-TEK data base
             quarantineRepository.reportMedicalConfirmation()
         }
     }
 
-    fun addOutgoingMessageYellow() {
+    fun reportPositiveSelfDiagnose() {
         launch {
             // Only set the sickness report date. Does not store keys in the saved-TEK data base
             quarantineRepository.reportPositiveSelfDiagnose()

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/base/DebugViewModel.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/base/DebugViewModel.kt
@@ -16,7 +16,7 @@ import org.threeten.bp.Instant
  */
 class DebugViewModel(
     appDispatchers: AppDispatchers,
-    private val infectionMessengerRepository: InfectionMessengerRepository,
+    private val diagnosisKeysRepository: DiagnosisKeysRepository,
     private val notificationsRepository: NotificationsRepository,
     private val quarantineRepository: QuarantineRepository,
     private val configurationRepository: ConfigurationRepository
@@ -37,7 +37,7 @@ class DebugViewModel(
 
     fun displaySomeoneHasRecoveredNotification() {
         launch {
-            infectionMessengerRepository.setSomeoneHasRecovered()
+            diagnosisKeysRepository.setSomeoneHasRecovered()
             notificationsRepository.displaySomeoneHasRecoveredNotification()
         }
     }

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardViewModel.kt
@@ -19,7 +19,7 @@ import org.threeten.bp.ZonedDateTime
 class DashboardViewModel(
     appDispatchers: AppDispatchers,
     private val dashboardRepository: DashboardRepository,
-    private val infectionMessengerRepository: InfectionMessengerRepository,
+    private val diagnosisKeysRepository: DiagnosisKeysRepository,
     private val quarantineRepository: QuarantineRepository,
     private val databaseCleanupManager: DatabaseCleanupManager,
     private val changelogManager: ChangelogManager,
@@ -105,7 +105,7 @@ class DashboardViewModel(
     }
 
     fun observeSomeoneHasRecoveredStatus(): Observable<HealthStatusData> {
-        return infectionMessengerRepository.observeSomeoneHasRecoveredMessage()
+        return diagnosisKeysRepository.observeSomeoneHasRecoveredMessage()
             .map { shouldShow ->
                 if (shouldShow) {
                     HealthStatusData.SomeoneHasRecovered
@@ -116,7 +116,7 @@ class DashboardViewModel(
     }
 
     fun someoneHasRecoveredSeen() {
-        infectionMessengerRepository.someoneHasRecoveredMessageSeen()
+        diagnosisKeysRepository.someoneHasRecoveredMessageSeen()
     }
 
     fun observeExposureNotificationPhase(): Observable<ExposureNotificationPhase> {

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/debug/diagnosis_keys/DebugDiagnosisKeysViewModel.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/debug/diagnosis_keys/DebugDiagnosisKeysViewModel.kt
@@ -10,7 +10,7 @@ import at.roteskreuz.stopcorona.model.exceptions.SilentError
 import at.roteskreuz.stopcorona.model.repositories.ConfigurationRepository
 import at.roteskreuz.stopcorona.model.repositories.ExposureNotificationRepository
 import at.roteskreuz.stopcorona.model.repositories.FilesRepository
-import at.roteskreuz.stopcorona.model.repositories.InfectionMessengerRepository
+import at.roteskreuz.stopcorona.model.repositories.DiagnosisKeysRepository
 import at.roteskreuz.stopcorona.model.repositories.other.ContextInteractor
 import at.roteskreuz.stopcorona.screens.reporting.reportStatus.ResolutionType
 import at.roteskreuz.stopcorona.skeleton.core.model.helpers.AppDispatchers
@@ -35,7 +35,7 @@ class DebugDiagnosisKeysViewModel(
     private val contextInteractor: ContextInteractor,
     private val exposureNotificationRepository: ExposureNotificationRepository,
     private val exposureNotificationClient: ExposureNotificationClient,
-    private val infectionMessengerRepository: InfectionMessengerRepository,
+    private val diagnosisKeysRepository: DiagnosisKeysRepository,
     private val filesRepository: FilesRepository,
     private val configurationRepository: ConfigurationRepository
 ) : ScopedViewModel(appDispatchers) {
@@ -243,7 +243,7 @@ class DebugDiagnosisKeysViewModel(
         launch(appDispatchers.Default) {
             try {
                 exposureNotificationsTextSubject.onNext("launching the diagnosis keys background processing")
-                infectionMessengerRepository.fetchAndForwardNewDiagnosisKeysToTheExposureNotificationFramework()
+                diagnosisKeysRepository.fetchAndForwardNewDiagnosisKeysToTheExposureNotificationFramework()
                 exposureNotificationsTextSubject.onNext("sucessfully launched the background processing")
             } catch (ex: Exception) {
                 exposureNotificationsTextSubject.onNext("error while launching the diagnosis keys background processing: $ex")

--- a/app/src/main/res/menu/debug.xml
+++ b/app/src/main/res/menu/debug.xml
@@ -31,14 +31,14 @@
                 </menu>
             </item>
             <item
-                android:id="@+id/debugMenuInfectionMessages"
-                android:title="InfectionMessages">
+                android:id="@+id/debugMenuReporting"
+                android:title="Reporting">
                 <menu>
                     <item
-                        android:id="@+id/debugMenuInfectionMessagesOutgoingRed"
+                        android:id="@+id/debugMenuReportMedicalConfirmation"
                         android:title="Outgoing Red" />
                     <item
-                        android:id="@+id/debugMenuInfectionMessagesOutgoingYellow"
+                        android:id="@+id/debugMenuReportPositiveSelfDiagnose"
                         android:title="Outgoing Yellow" />
                 </menu>
             </item>


### PR DESCRIPTION
## Changes

Rename InfectionMessengerRepository and other mentions of `infection messages`

## Solved issues

- none

## Dependencies

should be merged after the update of `develop`: #171 