### PR TITLE
Fix/ctaa 1691 reminder upload keys the next day

### DIFF
--- a/app/src/main/java/at/roteskreuz/stopcorona/App.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/App.kt
@@ -35,9 +35,6 @@ class App : BaseApp() {
 
         // Create notification channels
         createNotificationChannels()
-
-        val notificationsRepository: NotificationsRepository = get()
-        notificationsRepository.checkAndScheduleMissingKeysNotification()
     }
 
     private fun createNotificationChannels() {

--- a/app/src/main/java/at/roteskreuz/stopcorona/App.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/App.kt
@@ -7,7 +7,9 @@ import android.os.Build
 import at.roteskreuz.stopcorona.constants.Constants
 import at.roteskreuz.stopcorona.constants.isDebug
 import at.roteskreuz.stopcorona.di.*
+import at.roteskreuz.stopcorona.model.repositories.NotificationsRepository
 import at.roteskreuz.stopcorona.skeleton.core.BaseApp
+import org.koin.android.ext.android.get
 import org.koin.dsl.module.Module
 
 /**
@@ -33,6 +35,9 @@ class App : BaseApp() {
 
         // Create notification channels
         createNotificationChannels()
+
+        val notificationsRepository: NotificationsRepository = get()
+        notificationsRepository.checkAndScheduleMissingKeysNotification()
     }
 
     private fun createNotificationChannels() {
@@ -73,6 +78,14 @@ class App : BaseApp() {
             )
             channelAutomaticDetection.setShowBadge(false)
             notificationManager.createNotificationChannel(channelAutomaticDetection)
+
+            val channelUploadKeys = NotificationChannel(
+                Constants.NotificationChannels.CHANNEL_UPLOAD_KEYS,
+                getString(R.string.general_uploading_keys_channel_name),
+                NotificationManager.IMPORTANCE_HIGH
+            )
+            channelUploadKeys.setShowBadge(true)
+            notificationManager.createNotificationChannel(channelUploadKeys)
         }
     }
 }

--- a/app/src/main/java/at/roteskreuz/stopcorona/constants/Constants.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/constants/Constants.kt
@@ -160,6 +160,7 @@ object Constants {
         const val CHANNEL_RECOVERED = "channel_recovered"
         const val CHANNEL_QUARANTINE = "channel_quarantine"
         const val CHANNEL_AUTOMATIC_DETECTION = "channel_automatic_detection"
+        const val CHANNEL_UPLOAD_KEYS = "channel_upload_keys"
     }
 
     /**

--- a/app/src/main/java/at/roteskreuz/stopcorona/di/RepositoryModule.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/di/RepositoryModule.kt
@@ -59,9 +59,7 @@ val repositoryModule = module {
         NotificationsRepositoryImpl(
             appDispatchers = get(),
             contextInteractor = get(),
-            dataPrivacyRepository = get(),
-            quarantineRepository = get(),
-            workManager = get()
+            dataPrivacyRepository = get()
         )
     }
 

--- a/app/src/main/java/at/roteskreuz/stopcorona/di/RepositoryModule.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/di/RepositoryModule.kt
@@ -94,14 +94,16 @@ val repositoryModule = module {
         )
     }
 
-    single<ExposureNotificationManager> {
+    single<ExposureNotificationManager> (createOnStart = true) {
         ExposureNotificationManagerImpl(
             appDispatchers = get(),
             preferences = get(),
             exposureNotificationRepository = get(),
             bluetoothRepository = get(),
             googlePlayAvailability = get(),
-            contextInteractor = get()
+            contextInteractor = get(),
+            quarantineRepository = get(),
+            workManager = get()
         )
     }
 }

--- a/app/src/main/java/at/roteskreuz/stopcorona/di/RepositoryModule.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/di/RepositoryModule.kt
@@ -59,7 +59,9 @@ val repositoryModule = module {
         NotificationsRepositoryImpl(
             appDispatchers = get(),
             contextInteractor = get(),
-            dataPrivacyRepository = get()
+            dataPrivacyRepository = get(),
+            quarantineRepository = get(),
+            workManager = get()
         )
     }
 

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/NotificationsRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/NotificationsRepository.kt
@@ -83,11 +83,6 @@ interface NotificationsRepository {
      * Context: For privacy reasons, the key from today is not accessible until tomorrow.
      */
     fun displayNotificationForUploadingKeysFromTheDayBefore()
-
-    /**
-     * observe
-     */
-    fun checkAndScheduleMissingKeysNotification()
 }
 
 class NotificationsRepositoryImpl(
@@ -252,13 +247,7 @@ class NotificationsRepositoryImpl(
         ).show()
     }
 
-    override fun checkAndScheduleMissingKeysNotification(){
-        quarantineRepository.observeIfUploadOfMissingExposureKeysIsNeeded()
-            .observeOnMainThread()
-            .subscribe {
-                UploadKeysFromDayBeforeWorker.enqueueUploadKeysFromDayBeforeWorkerOnTheStartOfTheNextUtcDay(workManager)
-            }
-    }
+
 
     private fun buildNotification(
         title: String,

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/NotificationsRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/NotificationsRepository.kt
@@ -7,15 +7,18 @@ import android.content.Context
 import android.content.Intent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.TaskStackBuilder
+import androidx.work.WorkManager
 import at.roteskreuz.stopcorona.R
 import at.roteskreuz.stopcorona.constants.Constants.NotificationChannels
 import at.roteskreuz.stopcorona.model.entities.infection.info.WarningType
 import at.roteskreuz.stopcorona.model.entities.infection.message.MessageType
 import at.roteskreuz.stopcorona.model.repositories.other.ContextInteractor
+import at.roteskreuz.stopcorona.model.workers.UploadKeysFromDayBeforeWorker
 import at.roteskreuz.stopcorona.screens.dashboard.getDashboardActivityIntent
 import at.roteskreuz.stopcorona.screens.infection_info.getInfectionInfoFragmentIntent
 import at.roteskreuz.stopcorona.screens.questionnaire.getQuestionnaireIntent
 import at.roteskreuz.stopcorona.skeleton.core.model.helpers.AppDispatchers
+import at.roteskreuz.stopcorona.skeleton.core.utils.observeOnMainThread
 import at.roteskreuz.stopcorona.utils.string
 import kotlinx.coroutines.CoroutineScope
 import java.util.UUID
@@ -74,12 +77,25 @@ interface NotificationsRepository {
      * the Exposure Notifications Framework was too low to qualify for a quarantine.
      */
     fun displayNotificationForLowRisc()
+
+    /**
+     * Display a notification, reminding the user to upload the keys from the day before.
+     * Context: For privacy reasons, the key from today is not accessible until tomorrow.
+     */
+    fun displayNotificationForUploadingKeysFromTheDayBefore()
+
+    /**
+     * observe
+     */
+    fun checkAndScheduleMissingKeysNotification()
 }
 
 class NotificationsRepositoryImpl(
     private val appDispatchers: AppDispatchers,
     private val contextInteractor: ContextInteractor,
-    private val dataPrivacyRepository: DataPrivacyRepository
+    private val dataPrivacyRepository: DataPrivacyRepository,
+    private val quarantineRepository: QuarantineRepository,
+    private val workManager: WorkManager
 ) : NotificationsRepository,
     CoroutineScope {
 
@@ -219,6 +235,29 @@ class NotificationsRepositoryImpl(
             channelId = NotificationChannels.CHANNEL_INFECTION_MESSAGE,
             ongoing = false
         ).show()
+    }
+
+    override fun displayNotificationForUploadingKeysFromTheDayBefore() {
+        val title = context.string(R.string.upload_missing_keys_notification_title)
+        val message = context.string(R.string.upload_missing_keys_notification_message)
+
+        buildNotification(
+            title = title,
+            message = message,
+            pendingIntent = buildPendingIntentWithActivityStack {
+                addNextIntent(context.getDashboardActivityIntent().addFlags(firstActivityFlags))
+            },
+            channelId = NotificationChannels.CHANNEL_UPLOAD_KEYS,
+            ongoing = false
+        ).show()
+    }
+
+    override fun checkAndScheduleMissingKeysNotification(){
+        quarantineRepository.observeIfUploadOfMissingExposureKeysIsNeeded()
+            .observeOnMainThread()
+            .subscribe {
+                UploadKeysFromDayBeforeWorker.enqueueUploadKeysFromDayBeforeWorkerOnTheStartOfTheNextUtcDay(workManager)
+            }
     }
 
     private fun buildNotification(

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/NotificationsRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/NotificationsRepository.kt
@@ -88,9 +88,7 @@ interface NotificationsRepository {
 class NotificationsRepositoryImpl(
     private val appDispatchers: AppDispatchers,
     private val contextInteractor: ContextInteractor,
-    private val dataPrivacyRepository: DataPrivacyRepository,
-    private val quarantineRepository: QuarantineRepository,
-    private val workManager: WorkManager
+    private val dataPrivacyRepository: DataPrivacyRepository
 ) : NotificationsRepository,
     CoroutineScope {
 

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/QuarantineRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/QuarantineRepository.kt
@@ -464,8 +464,7 @@ class QuarantineRepositoryImpl(
         ).debounce(50, TimeUnit.MILLISECONDS) // some of the shared prefs can be changed together
             .map { (dateOfFirstMedicalConfirmation, dateOfLastSelfDiagnose, areMissingKeysUploaded) ->
                 if (dateOfFirstMedicalConfirmation.isPresent &&
-                    ZonedDateTime.now()
-                        .isAfter(dateOfFirstMedicalConfirmation.get().endOfTheUtcDay()) &&
+                    ZonedDateTime.now().isAfter(dateOfFirstMedicalConfirmation.get().endOfTheUtcDay()) &&
                     areMissingKeysUploaded.not()
                 ) {
                     Optional.of(UploadMissingExposureKeys(
@@ -473,8 +472,7 @@ class QuarantineRepositoryImpl(
                         MessageType.InfectionLevel.Red
                     ))
                 } else if (dateOfLastSelfDiagnose.isPresent &&
-                    ZonedDateTime.now()
-                        .isAfter(dateOfLastSelfDiagnose.get().endOfTheUtcDay()) &&
+                    ZonedDateTime.now().isAfter(dateOfLastSelfDiagnose.get().endOfTheUtcDay()) &&
                     areMissingKeysUploaded.not()
                 ) {
                     Optional.of(UploadMissingExposureKeys(

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/workers/UploadKeysFromDayBeforeWorker.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/workers/UploadKeysFromDayBeforeWorker.kt
@@ -1,0 +1,48 @@
+package at.roteskreuz.stopcorona.model.workers
+
+import android.content.Context
+import androidx.work.*
+import at.roteskreuz.stopcorona.model.repositories.BluetoothRepository
+import at.roteskreuz.stopcorona.model.repositories.ExposureNotificationRepository
+import at.roteskreuz.stopcorona.model.repositories.NotificationsRepository
+import at.roteskreuz.stopcorona.utils.millisUntilTheStartOfTheNextUtcDay
+import at.roteskreuz.stopcorona.utils.minus
+import at.roteskreuz.stopcorona.utils.startOfTheDay
+import at.roteskreuz.stopcorona.utils.startOfTheUtcDay
+import org.koin.standalone.KoinComponent
+import org.koin.standalone.inject
+import org.threeten.bp.ZonedDateTime
+import java.util.concurrent.TimeUnit
+
+/**
+ * Worker to remind the user to upload his/hers keys from the day before.
+ */
+class UploadKeysFromDayBeforeWorker(
+    appContext: Context,
+    workerParams: WorkerParameters
+) : CoroutineWorker(appContext, workerParams), KoinComponent {
+
+    companion object {
+        private const val TAG = "UploadKeysFromDayBeforeWorker"
+
+
+        fun enqueueUploadKeysFromDayBeforeWorkerOnTheStartOfTheNextUtcDay(workManager: WorkManager) {
+            val request = OneTimeWorkRequestBuilder<UploadKeysFromDayBeforeWorker>()
+                .setInitialDelay(ZonedDateTime.now().millisUntilTheStartOfTheNextUtcDay(), TimeUnit.MILLISECONDS)
+                .build()
+
+            workManager.enqueueUniqueWork(
+                TAG,
+                ExistingWorkPolicy.REPLACE,
+                request
+            )
+        }
+    }
+
+    private val notificationsRepository: NotificationsRepository by inject()
+
+    override suspend fun doWork(): Result {
+        notificationsRepository.displayNotificationForUploadingKeysFromTheDayBefore()
+        return Result.success()
+    }
+}

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/base/CoronaBaseActivity.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/base/CoronaBaseActivity.kt
@@ -57,6 +57,10 @@ open class CoronaBaseActivity(@LayoutRes layout: Int = R.layout.framelayout) : B
                 debugViewModel.displayEndQuarantineNotification()
                 true
             }
+            R.id.debugMenuNotificationUploadKeys -> {
+                debugViewModel.displayNotificationForUploadingKeysFromTheDayBefore()
+                true
+            }
             R.id.debugMenuQuarantineStatus -> {
                 val quarantineStatus = debugViewModel.getQuarantineStatus()
                 Toast.makeText(this, quarantineStatus.toString(), Toast.LENGTH_LONG).show()

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/base/DebugViewModel.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/base/DebugViewModel.kt
@@ -82,4 +82,8 @@ class DebugViewModel(
             quarantineRepository.receivedWarning(WarningType.YELLOW, quarantineDay)
         }
     }
+
+    fun displayNotificationForUploadingKeysFromTheDayBefore() {
+        notificationsRepository.displayNotificationForUploadingKeysFromTheDayBefore()
+    }
 }

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardController.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardController.kt
@@ -451,10 +451,11 @@ class DashboardController(
                 .addTo(modelList)
         }
 
-        if ((ownHealthStatus is HealthStatusData.SelfTestingSuspicionOfSickness ||
-                ownHealthStatus is HealthStatusData.SicknessCertificate) &&
-            uploadMissingExposureKeys.isPresent
-        ) {
+        val healthStatusDataMatches =
+            ownHealthStatus is HealthStatusData.SelfTestingSuspicionOfSickness ||
+            ownHealthStatus is HealthStatusData.SicknessCertificate
+
+        if (healthStatusDataMatches && uploadMissingExposureKeys.isPresent) {
             EmptySpaceModel_()
                 .id(modelCountBuiltSoFar)
                 .height(16)

--- a/app/src/main/java/at/roteskreuz/stopcorona/utils/DateTimeExtensions.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/utils/DateTimeExtensions.kt
@@ -244,3 +244,7 @@ fun Instant.plusDays(days: Long): Instant = plus(days, ChronoUnit.DAYS)
  * Provides method known from ZonedDateTime
  */
 fun Instant.minusDays(days: Long): Instant = minus(days, ChronoUnit.DAYS)
+
+fun ZonedDateTime.millisUntilTheStartOfTheNextUtcDay(): Long {
+    return (ZonedDateTime.now().plusDays(1).startOfTheUtcDay() - this).toMillis()
+}

--- a/app/src/main/java/at/roteskreuz/stopcorona/utils/DateTimeExtensions.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/utils/DateTimeExtensions.kt
@@ -246,5 +246,5 @@ fun Instant.plusDays(days: Long): Instant = plus(days, ChronoUnit.DAYS)
 fun Instant.minusDays(days: Long): Instant = minus(days, ChronoUnit.DAYS)
 
 fun ZonedDateTime.millisUntilTheStartOfTheNextUtcDay(): Long {
-    return (ZonedDateTime.now().plusDays(1).startOfTheUtcDay() - this).toMillis()
+    return (this.plusDays(1).startOfTheUtcDay() - this).toMillis()
 }

--- a/app/src/main/res/menu/debug.xml
+++ b/app/src/main/res/menu/debug.xml
@@ -28,6 +28,9 @@
                     <item
                         android:id="@+id/debugMenuNotificationEndQuarantine"
                         android:title="End of quarantine" />
+                    <item
+                        android:id="@+id/debugMenuNotificationUploadKeys"
+                        android:title="Upload Keys from yesterday" />
                 </menu>
             </item>
             <item

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -10,6 +10,7 @@
 	<string name="general_self_recovered_channel_name">Einige haben Bekanntmachungen wiederhergestellt</string>
 	<string name="general_self_quarantine_channel_name">Quarantänemitteilungen</string>
 	<string name="general_automatic_bt_detection_channel_name">Automatische Benachrichtigungen zur Erkennung von Bluetooth-Geräten</string>
+	<string name="general_uploading_keys_channel_name">Hinweise zur Hochladen der eigenen Schlüssel</string>
 	<string name="general_continue">Weiter</string>
 	<string name="general_additional_information">Weitere Informationen</string>
 
@@ -435,6 +436,8 @@
 	<string name="local_notification_activate_automatic_handshake_again_title">Bitte aktivieren Sie den automatischen Handshake wieder</string>
 	<string name="local_notification_activate_automatic_handshake_again_message">Und helfen Sie weiter bei der Eindämmung des Coronavirus.</string>
 	<string name="upload_missing_keys">Neue Kontakte benachrichtigen</string>
+	<string name="upload_missing_keys_notification_title">Neue Kontakte benachrichtigen</string>
+	<string name="upload_missing_keys_notification_message">Benachrichtigen Sie Personen, mit denen Sie seit Ihrer letzten Meldung einen digitalen Handshake ausgetauscht haben.</string>
 
 	<!-- Contacts Health Status Info -->
 	<string name="contacts_confirmed_one_case_headline">Achtung</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
 	<string name="general_self_recovered_channel_name">Some has recovered notices</string>
 	<string name="general_self_quarantine_channel_name">Quarantine notices</string>
 	<string name="general_automatic_bt_detection_channel_name">Automatic Bluetooth device detection notices</string>
-	<string name="general_uploading_keys_channel_name">Notices gerarding the uploading of your owm keys</string>
+	<string name="general_uploading_keys_channel_name">Notices regarding the uploading of your own keys</string>
 	<string name="general_continue">Continue</string>
 	<string name="general_additional_information">Further information</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
 	<string name="general_self_recovered_channel_name">Some has recovered notices</string>
 	<string name="general_self_quarantine_channel_name">Quarantine notices</string>
 	<string name="general_automatic_bt_detection_channel_name">Automatic Bluetooth device detection notices</string>
+	<string name="general_uploading_keys_channel_name">Notices gerarding the uploading of your owm keys</string>
 	<string name="general_continue">Continue</string>
 	<string name="general_additional_information">Further information</string>
 
@@ -435,6 +436,8 @@
 	<string name="local_notification_activate_automatic_handshake_again_title">Please activate the automatic handshake again</string>
 	<string name="local_notification_activate_automatic_handshake_again_message">and continue to help contain the corona virus.</string>
 	<string name="upload_missing_keys">Notify new contacts</string>
+	<string name="upload_missing_keys_notification_title">Notify new contacts</string>
+	<string name="upload_missing_keys_notification_message">Notify people with whom you have exchanged a digital handshake since your last message.</string>
 
 	<!-- Contacts Health Status Info -->
 	<string name="contacts_confirmed_one_case_headline">Caution</string>

--- a/app/src/test/java/at/roteskreuz/stopcorona/model/entities/session/DbFullBatchPartTest.kt
+++ b/app/src/test/java/at/roteskreuz/stopcorona/model/entities/session/DbFullBatchPartTest.kt
@@ -5,7 +5,7 @@ import org.junit.Test
 class DbFullBatchPartTest {
 
     @Test
-    fun testSomeSorting() {
+    fun `just a random test to make sure sortedBy sorts ascending`() {
         val part1 = DbFullBatchPart(
             sessionId = 1,
             batchNumber = 1,

--- a/app/src/test/java/at/roteskreuz/stopcorona/model/entities/session/DbFullBatchPartTest.kt
+++ b/app/src/test/java/at/roteskreuz/stopcorona/model/entities/session/DbFullBatchPartTest.kt
@@ -5,7 +5,7 @@ import org.junit.Test
 class DbFullBatchPartTest {
 
     @Test
-    fun getIntervalStart() {
+    fun testSomeSorting() {
         val part1 = DbFullBatchPart(
             sessionId = 1,
             batchNumber = 1,

--- a/app/src/test/java/at/roteskreuz/stopcorona/model/repositories/QuarantineStatusTest.kt
+++ b/app/src/test/java/at/roteskreuz/stopcorona/model/repositories/QuarantineStatusTest.kt
@@ -18,7 +18,7 @@ import org.threeten.bp.ZonedDateTime
 class QuarantineStatusTest {
 
     @Test
-    fun testDaysUntilTodayToBeOne(){
+    fun `days until end of quarantine today needs to be 1`(){
         val endsToday = ZonedDateTime.now().plusHours(1)
         val limited = QuarantineStatus.Jailed.Limited(end = endsToday, byContact = true)
 
@@ -26,7 +26,7 @@ class QuarantineStatusTest {
     }
 
     @Test
-    fun testDaysUntilSevenDaysToBeEight(){
+    fun `7 days of quarantine actually show as 8 days`(){
         val endsToday = ZonedDateTime.now().plusDays(7)
         val limited = QuarantineStatus.Jailed.Limited(end = endsToday, byContact = true)
 

--- a/app/src/test/java/at/roteskreuz/stopcorona/utils/DateTimeExtensionsKtTest.kt
+++ b/app/src/test/java/at/roteskreuz/stopcorona/utils/DateTimeExtensionsKtTest.kt
@@ -9,7 +9,7 @@ import org.threeten.bp.ZonedDateTime
 class DateTimeExtensionsKtTest {
 
     @Test
-    fun millisUntilTheStartOfTheNextUtcDay() {
+    fun `test milliseconds calculation to the next UTC day`() {
 
         val todayNoon: ZonedDateTime = ZonedDateTime.now()
             .withZoneSameLocal(ZoneId.of("UTC+2"))

--- a/app/src/test/java/at/roteskreuz/stopcorona/utils/DateTimeExtensionsKtTest.kt
+++ b/app/src/test/java/at/roteskreuz/stopcorona/utils/DateTimeExtensionsKtTest.kt
@@ -1,0 +1,24 @@
+package at.roteskreuz.stopcorona.utils
+
+import org.junit.Test
+
+import org.junit.Assert.*
+import org.threeten.bp.ZoneId
+import org.threeten.bp.ZonedDateTime
+
+class DateTimeExtensionsKtTest {
+
+    @Test
+    fun millisUntilTheStartOfTheNextUtcDay() {
+
+        val todayNoon: ZonedDateTime = ZonedDateTime.now()
+            .withZoneSameLocal(ZoneId.of("UTC+2"))
+            .withHour(12)
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0)
+        // 12 hours + 2 hours offset 
+        assertEquals((12+2)*60*60*1000,todayNoon.millisUntilTheStartOfTheNextUtcDay())
+
+    }
+}

--- a/app/src/test/java/at/roteskreuz/stopcorona/utils/ExposureNotficationExtensionsKtTest.kt
+++ b/app/src/test/java/at/roteskreuz/stopcorona/utils/ExposureNotficationExtensionsKtTest.kt
@@ -31,7 +31,7 @@ class ExposureNotficationExtensionsKtTest {
         .build()
 
     @Test
-    fun testEmpty() {
+    fun `no exposures lead to no exposure dates`() {
         val listUnderTest: List<ExposureInformation> = emptyList()
 
         val dates = listUnderTest.extractLatestRedAndYellowContactDate(THRESHOLD)
@@ -41,7 +41,7 @@ class ExposureNotficationExtensionsKtTest {
     }
 
     @Test
-    fun ignoreSingleUnriskyYellow() {
+    fun `a single yellow exposure information leads to a the yellow date on that day`() {
         val listUnderTest: List<ExposureInformation> = arrayListOf(SHORT_YELLOW_TWO_DAYS_AGO)
 
         val dates = listUnderTest.extractLatestRedAndYellowContactDate(THRESHOLD)
@@ -51,7 +51,7 @@ class ExposureNotficationExtensionsKtTest {
     }
 
     @Test
-    fun twoUnriskyTriggerYellowWarning() {
+    fun `two individual yellow exposures, individually not relevant must lead to a combined yellow warning`() {
         val listUnderTest: List<ExposureInformation> = arrayListOf(SHORT_YELLOW_TWO_DAYS_AGO, SHORT_YELLOW_TWO_DAYS_AGO)
 
         val dates = listUnderTest.extractLatestRedAndYellowContactDate(THRESHOLD)
@@ -62,7 +62,7 @@ class ExposureNotficationExtensionsKtTest {
     }
 
     @Test
-    fun detectSimpleRed() {
+    fun `detect a single red exposure day`() {
 
         val listUnderTest: List<ExposureInformation> = arrayListOf(RED_YESTERDAY)
 
@@ -74,7 +74,7 @@ class ExposureNotficationExtensionsKtTest {
     }
 
     @Test
-    fun detectTwoRed_detectLatest_orderIrrelevant() {
+    fun `detect the latest red day irrelevant of the order of the exposures in the list of exposures`() {
 
         val listUnderTest: List<ExposureInformation> = arrayListOf(RED_TWO_DAYS_AGO, RED_YESTERDAY)
         val listUnderTest2: List<ExposureInformation> = arrayListOf(RED_YESTERDAY, RED_YESTERDAY)


### PR DESCRIPTION
## Changes

* remind user to upload the key from yesterday

Context: For privacy reasons, the key from today is not accessible until tomorrow.

Notification will link to this screen: 
<a href="https://user-images.githubusercontent.com/50506/85841772-e3a24600-b79e-11ea-8f14-1635f6a3734e.png"><img src="https://user-images.githubusercontent.com/50506/85841772-e3a24600-b79e-11ea-8f14-1635f6a3734e.png" width="300"/></a>

## UI changes in this PR
<img src="https://user-images.githubusercontent.com/50506/85871378-99d15400-b7ce-11ea-9500-6c07bbb82910.png" width="300"/><img src="https://user-images.githubusercontent.com/50506/85871381-9a69ea80-b7ce-11ea-80af-a040ef61a269.png" width="300"/>


## Solved issues

- [Issue #1691](https://tasks.pxp-x.com/browse/CTAA-1691)
