### PR TITLE
Fix story/ctaa 1691 reminder to upload keys

### DIFF
--- a/app/src/main/java/at/roteskreuz/stopcorona/App.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/App.kt
@@ -35,9 +35,6 @@ class App : BaseApp() {
 
         // Create notification channels
         createNotificationChannels()
-
-        val notificationsRepository: NotificationsRepository = get()
-        notificationsRepository.checkAndScheduleMissingKeysNotification()
     }
 
     private fun createNotificationChannels() {

--- a/app/src/main/java/at/roteskreuz/stopcorona/App.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/App.kt
@@ -7,7 +7,9 @@ import android.os.Build
 import at.roteskreuz.stopcorona.constants.Constants
 import at.roteskreuz.stopcorona.constants.isDebug
 import at.roteskreuz.stopcorona.di.*
+import at.roteskreuz.stopcorona.model.repositories.NotificationsRepository
 import at.roteskreuz.stopcorona.skeleton.core.BaseApp
+import org.koin.android.ext.android.get
 import org.koin.dsl.module.Module
 
 /**
@@ -33,6 +35,9 @@ class App : BaseApp() {
 
         // Create notification channels
         createNotificationChannels()
+
+        val notificationsRepository: NotificationsRepository = get()
+        notificationsRepository.checkAndScheduleMissingKeysNotification()
     }
 
     private fun createNotificationChannels() {
@@ -73,6 +78,14 @@ class App : BaseApp() {
             )
             channelAutomaticDetection.setShowBadge(false)
             notificationManager.createNotificationChannel(channelAutomaticDetection)
+
+            val channelUploadKeys = NotificationChannel(
+                Constants.NotificationChannels.CHANNEL_UPLOAD_KEYS,
+                getString(R.string.general_uploading_keys_channel_name),
+                NotificationManager.IMPORTANCE_HIGH
+            )
+            channelUploadKeys.setShowBadge(true)
+            notificationManager.createNotificationChannel(channelUploadKeys)
         }
     }
 }

--- a/app/src/main/java/at/roteskreuz/stopcorona/constants/Constants.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/constants/Constants.kt
@@ -160,6 +160,7 @@ object Constants {
         const val CHANNEL_RECOVERED = "channel_recovered"
         const val CHANNEL_QUARANTINE = "channel_quarantine"
         const val CHANNEL_AUTOMATIC_DETECTION = "channel_automatic_detection"
+        const val CHANNEL_UPLOAD_KEYS = "channel_upload_keys"
     }
 
     /**

--- a/app/src/main/java/at/roteskreuz/stopcorona/di/RepositoryModule.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/di/RepositoryModule.kt
@@ -59,9 +59,7 @@ val repositoryModule = module {
         NotificationsRepositoryImpl(
             appDispatchers = get(),
             contextInteractor = get(),
-            dataPrivacyRepository = get(),
-            quarantineRepository = get(),
-            workManager = get()
+            dataPrivacyRepository = get()
         )
     }
 

--- a/app/src/main/java/at/roteskreuz/stopcorona/di/RepositoryModule.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/di/RepositoryModule.kt
@@ -94,14 +94,16 @@ val repositoryModule = module {
         )
     }
 
-    single<ExposureNotificationManager> {
+    single<ExposureNotificationManager> (createOnStart = true) {
         ExposureNotificationManagerImpl(
             appDispatchers = get(),
             preferences = get(),
             exposureNotificationRepository = get(),
             bluetoothRepository = get(),
             googlePlayAvailability = get(),
-            contextInteractor = get()
+            contextInteractor = get(),
+            quarantineRepository = get(),
+            workManager = get()
         )
     }
 }

--- a/app/src/main/java/at/roteskreuz/stopcorona/di/RepositoryModule.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/di/RepositoryModule.kt
@@ -59,7 +59,9 @@ val repositoryModule = module {
         NotificationsRepositoryImpl(
             appDispatchers = get(),
             contextInteractor = get(),
-            dataPrivacyRepository = get()
+            dataPrivacyRepository = get(),
+            quarantineRepository = get(),
+            workManager = get()
         )
     }
 

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/NotificationsRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/NotificationsRepository.kt
@@ -83,11 +83,6 @@ interface NotificationsRepository {
      * Context: For privacy reasons, the key from today is not accessible until tomorrow.
      */
     fun displayNotificationForUploadingKeysFromTheDayBefore()
-
-    /**
-     * observe
-     */
-    fun checkAndScheduleMissingKeysNotification()
 }
 
 class NotificationsRepositoryImpl(
@@ -252,13 +247,7 @@ class NotificationsRepositoryImpl(
         ).show()
     }
 
-    override fun checkAndScheduleMissingKeysNotification(){
-        quarantineRepository.observeIfUploadOfMissingExposureKeysIsNeeded()
-            .observeOnMainThread()
-            .subscribe {
-                UploadKeysFromDayBeforeWorker.enqueueUploadKeysFromDayBeforeWorkerOnTheStartOfTheNextUtcDay(workManager)
-            }
-    }
+
 
     private fun buildNotification(
         title: String,

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/NotificationsRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/NotificationsRepository.kt
@@ -7,15 +7,18 @@ import android.content.Context
 import android.content.Intent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.TaskStackBuilder
+import androidx.work.WorkManager
 import at.roteskreuz.stopcorona.R
 import at.roteskreuz.stopcorona.constants.Constants.NotificationChannels
 import at.roteskreuz.stopcorona.model.entities.infection.info.WarningType
 import at.roteskreuz.stopcorona.model.entities.infection.message.MessageType
 import at.roteskreuz.stopcorona.model.repositories.other.ContextInteractor
+import at.roteskreuz.stopcorona.model.workers.UploadKeysFromDayBeforeWorker
 import at.roteskreuz.stopcorona.screens.dashboard.getDashboardActivityIntent
 import at.roteskreuz.stopcorona.screens.infection_info.getInfectionInfoFragmentIntent
 import at.roteskreuz.stopcorona.screens.questionnaire.getQuestionnaireIntent
 import at.roteskreuz.stopcorona.skeleton.core.model.helpers.AppDispatchers
+import at.roteskreuz.stopcorona.skeleton.core.utils.observeOnMainThread
 import at.roteskreuz.stopcorona.utils.string
 import kotlinx.coroutines.CoroutineScope
 import java.util.UUID
@@ -74,12 +77,25 @@ interface NotificationsRepository {
      * the Exposure Notifications Framework was too low to qualify for a quarantine.
      */
     fun displayNotificationForLowRisc()
+
+    /**
+     * Display a notification, reminding the user to upload the keys from the day before.
+     * Context: For privacy reasons, the key from today is not accessible until tomorrow.
+     */
+    fun displayNotificationForUploadingKeysFromTheDayBefore()
+
+    /**
+     * observe
+     */
+    fun checkAndScheduleMissingKeysNotification()
 }
 
 class NotificationsRepositoryImpl(
     private val appDispatchers: AppDispatchers,
     private val contextInteractor: ContextInteractor,
-    private val dataPrivacyRepository: DataPrivacyRepository
+    private val dataPrivacyRepository: DataPrivacyRepository,
+    private val quarantineRepository: QuarantineRepository,
+    private val workManager: WorkManager
 ) : NotificationsRepository,
     CoroutineScope {
 
@@ -219,6 +235,29 @@ class NotificationsRepositoryImpl(
             channelId = NotificationChannels.CHANNEL_INFECTION_MESSAGE,
             ongoing = false
         ).show()
+    }
+
+    override fun displayNotificationForUploadingKeysFromTheDayBefore() {
+        val title = context.string(R.string.upload_missing_keys_notification_title)
+        val message = context.string(R.string.upload_missing_keys_notification_message)
+
+        buildNotification(
+            title = title,
+            message = message,
+            pendingIntent = buildPendingIntentWithActivityStack {
+                addNextIntent(context.getDashboardActivityIntent().addFlags(firstActivityFlags))
+            },
+            channelId = NotificationChannels.CHANNEL_UPLOAD_KEYS,
+            ongoing = false
+        ).show()
+    }
+
+    override fun checkAndScheduleMissingKeysNotification(){
+        quarantineRepository.observeIfUploadOfMissingExposureKeysIsNeeded()
+            .observeOnMainThread()
+            .subscribe {
+                UploadKeysFromDayBeforeWorker.enqueueUploadKeysFromDayBeforeWorkerOnTheStartOfTheNextUtcDay(workManager)
+            }
     }
 
     private fun buildNotification(

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/NotificationsRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/NotificationsRepository.kt
@@ -88,9 +88,7 @@ interface NotificationsRepository {
 class NotificationsRepositoryImpl(
     private val appDispatchers: AppDispatchers,
     private val contextInteractor: ContextInteractor,
-    private val dataPrivacyRepository: DataPrivacyRepository,
-    private val quarantineRepository: QuarantineRepository,
-    private val workManager: WorkManager
+    private val dataPrivacyRepository: DataPrivacyRepository
 ) : NotificationsRepository,
     CoroutineScope {
 

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/QuarantineRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/QuarantineRepository.kt
@@ -464,8 +464,7 @@ class QuarantineRepositoryImpl(
         ).debounce(50, TimeUnit.MILLISECONDS) // some of the shared prefs can be changed together
             .map { (dateOfFirstMedicalConfirmation, dateOfLastSelfDiagnose, areMissingKeysUploaded) ->
                 if (dateOfFirstMedicalConfirmation.isPresent &&
-                    ZonedDateTime.now()
-                        .isAfter(dateOfFirstMedicalConfirmation.get().endOfTheUtcDay()) &&
+                    ZonedDateTime.now().isAfter(dateOfFirstMedicalConfirmation.get().endOfTheUtcDay()) &&
                     areMissingKeysUploaded.not()
                 ) {
                     Optional.of(UploadMissingExposureKeys(
@@ -473,8 +472,7 @@ class QuarantineRepositoryImpl(
                         MessageType.InfectionLevel.Red
                     ))
                 } else if (dateOfLastSelfDiagnose.isPresent &&
-                    ZonedDateTime.now()
-                        .isAfter(dateOfLastSelfDiagnose.get().endOfTheUtcDay()) &&
+                    ZonedDateTime.now().isAfter(dateOfLastSelfDiagnose.get().endOfTheUtcDay()) &&
                     areMissingKeysUploaded.not()
                 ) {
                     Optional.of(UploadMissingExposureKeys(

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/workers/UploadKeysFromDayBeforeWorker.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/workers/UploadKeysFromDayBeforeWorker.kt
@@ -1,0 +1,48 @@
+package at.roteskreuz.stopcorona.model.workers
+
+import android.content.Context
+import androidx.work.*
+import at.roteskreuz.stopcorona.model.repositories.BluetoothRepository
+import at.roteskreuz.stopcorona.model.repositories.ExposureNotificationRepository
+import at.roteskreuz.stopcorona.model.repositories.NotificationsRepository
+import at.roteskreuz.stopcorona.utils.millisUntilTheStartOfTheNextUtcDay
+import at.roteskreuz.stopcorona.utils.minus
+import at.roteskreuz.stopcorona.utils.startOfTheDay
+import at.roteskreuz.stopcorona.utils.startOfTheUtcDay
+import org.koin.standalone.KoinComponent
+import org.koin.standalone.inject
+import org.threeten.bp.ZonedDateTime
+import java.util.concurrent.TimeUnit
+
+/**
+ * Worker to remind the user to upload his/hers keys from the day before.
+ */
+class UploadKeysFromDayBeforeWorker(
+    appContext: Context,
+    workerParams: WorkerParameters
+) : CoroutineWorker(appContext, workerParams), KoinComponent {
+
+    companion object {
+        private const val TAG = "UploadKeysFromDayBeforeWorker"
+
+
+        fun enqueueUploadKeysFromDayBeforeWorkerOnTheStartOfTheNextUtcDay(workManager: WorkManager) {
+            val request = OneTimeWorkRequestBuilder<UploadKeysFromDayBeforeWorker>()
+                .setInitialDelay(ZonedDateTime.now().millisUntilTheStartOfTheNextUtcDay(), TimeUnit.MILLISECONDS)
+                .build()
+
+            workManager.enqueueUniqueWork(
+                TAG,
+                ExistingWorkPolicy.REPLACE,
+                request
+            )
+        }
+    }
+
+    private val notificationsRepository: NotificationsRepository by inject()
+
+    override suspend fun doWork(): Result {
+        notificationsRepository.displayNotificationForUploadingKeysFromTheDayBefore()
+        return Result.success()
+    }
+}

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/base/CoronaBaseActivity.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/base/CoronaBaseActivity.kt
@@ -74,6 +74,10 @@ open class CoronaBaseActivity(@LayoutRes layout: Int = R.layout.framelayout) : B
                 debugViewModel.reportPositiveSelfDiagnose()
                 true
             }
+            R.id.debugMenuReportYesterdayKey -> {
+                debugViewModel.fakeReportWithMissingKeysYesterday()
+                true
+            }
             R.id.debugExposureNotifications -> {
                 startDebugExposureNotificationsFragment()
                 true

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/base/CoronaBaseActivity.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/base/CoronaBaseActivity.kt
@@ -57,6 +57,10 @@ open class CoronaBaseActivity(@LayoutRes layout: Int = R.layout.framelayout) : B
                 debugViewModel.displayEndQuarantineNotification()
                 true
             }
+            R.id.debugMenuNotificationUploadKeys -> {
+                debugViewModel.displayNotificationForUploadingKeysFromTheDayBefore()
+                true
+            }
             R.id.debugMenuQuarantineStatus -> {
                 val quarantineStatus = debugViewModel.getQuarantineStatus()
                 Toast.makeText(this, quarantineStatus.toString(), Toast.LENGTH_LONG).show()

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/base/DebugViewModel.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/base/DebugViewModel.kt
@@ -82,4 +82,8 @@ class DebugViewModel(
             quarantineRepository.receivedWarning(WarningType.YELLOW, quarantineDay)
         }
     }
+
+    fun displayNotificationForUploadingKeysFromTheDayBefore() {
+        notificationsRepository.displayNotificationForUploadingKeysFromTheDayBefore()
+    }
 }

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/base/DebugViewModel.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/base/DebugViewModel.kt
@@ -8,6 +8,7 @@ import at.roteskreuz.stopcorona.skeleton.core.screens.base.viewmodel.ScopedViewM
 import at.roteskreuz.stopcorona.utils.minusDays
 import kotlinx.coroutines.launch
 import org.threeten.bp.Instant
+import org.threeten.bp.ZonedDateTime
 
 /**
  * Special viewModel for managing debug tasks.
@@ -85,5 +86,10 @@ class DebugViewModel(
 
     fun displayNotificationForUploadingKeysFromTheDayBefore() {
         notificationsRepository.displayNotificationForUploadingKeysFromTheDayBefore()
+    }
+
+    fun fakeReportWithMissingKeysYesterday() {
+        quarantineRepository.markMissingExposureKeysAsNotUploaded()
+        quarantineRepository.reportMedicalConfirmation(ZonedDateTime.now().minusDays(1))
     }
 }

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardController.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardController.kt
@@ -20,7 +20,6 @@ import at.roteskreuz.stopcorona.utils.startOfTheDay
 import at.roteskreuz.stopcorona.utils.string
 import com.airbnb.epoxy.EpoxyController
 import com.airbnb.epoxy.EpoxyModel
-import com.github.dmstocking.optional.java.util.Optional
 import org.threeten.bp.ZonedDateTime
 
 /**
@@ -50,7 +49,7 @@ class DashboardController(
     var someoneHasRecoveredHealthStatus: HealthStatusData by adapterProperty(HealthStatusData.NoHealthStatus)
     var exposureNotificationPhase: ExposureNotificationPhase? by adapterProperty(null as ExposureNotificationPhase?)
     var dateOfFirstMedicalConfirmation: ZonedDateTime? by adapterProperty(null as ZonedDateTime?)
-    var uploadMissingExposureKeys: Optional<UploadMissingExposureKeys> by adapterProperty(Optional.empty())
+    var uploadMissingExposureKeys: UploadMissingExposureKeys? by adapterProperty(null as UploadMissingExposureKeys?)
 
     override fun buildModels() {
         emptySpace(modelCountBuiltSoFar, 16)
@@ -453,9 +452,10 @@ class DashboardController(
 
         val healthStatusDataMatches =
             ownHealthStatus is HealthStatusData.SelfTestingSuspicionOfSickness ||
-            ownHealthStatus is HealthStatusData.SicknessCertificate
+                ownHealthStatus is HealthStatusData.SicknessCertificate
 
-        if (healthStatusDataMatches && uploadMissingExposureKeys.isPresent) {
+        val uploadMissingExposureKeys = uploadMissingExposureKeys
+        if (healthStatusDataMatches && uploadMissingExposureKeys != null) {
             EmptySpaceModel_()
                 .id(modelCountBuiltSoFar)
                 .height(16)
@@ -464,16 +464,16 @@ class DashboardController(
             ButtonType2Model_ {
                 onUploadMissingExposureKeysClick(
                     false,
-                    uploadMissingExposureKeys.get()
+                    uploadMissingExposureKeys
                 )
             }
                 .id("own_health_status_upload_missing_exposure_keys")
-                .text(context.string(R.string.upload_missing_keys))
+                .text(context.string(R.string.upload_missing_keys_notification_title))
                 .enabled(exposureNotificationPhase.isReportingEnabled())
                 .onDisabledClick {
                     onUploadMissingExposureKeysClick(
                         true,
-                        uploadMissingExposureKeys.get()
+                        uploadMissingExposureKeys
                     )
                 }
                 .addTo(modelList)

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardController.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardController.kt
@@ -1,6 +1,7 @@
 package at.roteskreuz.stopcorona.screens.dashboard
 
 import android.content.Context
+import android.text.SpannableString
 import at.roteskreuz.stopcorona.R
 import at.roteskreuz.stopcorona.constants.Constants
 import at.roteskreuz.stopcorona.model.managers.ExposureNotificationPhase
@@ -461,14 +462,24 @@ class DashboardController(
                 .height(16)
                 .addTo(modelList)
 
+            CopyTextModel_()
+                .id("own_health_status_upload_missing_exposure_keys_explanation")
+                .text(SpannableString(context.string(R.string.self_testing_symptoms_warning_info_update)))
+                .addTo(modelList)
+
+            EmptySpaceModel_()
+                .id(modelCountBuiltSoFar)
+                .height(16)
+                .addTo(modelList)
+
             ButtonType2Model_ {
                 onUploadMissingExposureKeysClick(
                     false,
                     uploadMissingExposureKeys
                 )
             }
-                .id("own_health_status_upload_missing_exposure_keys")
-                .text(context.string(R.string.upload_missing_keys_notification_title))
+                .id("own_health_status_upload_missing_exposure_keys_button")
+                .text(context.string(R.string.self_testing_symptoms_warning_button_update))
                 .enabled(exposureNotificationPhase.isReportingEnabled())
                 .onDisabledClick {
                     onUploadMissingExposureKeysClick(

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardController.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardController.kt
@@ -451,10 +451,11 @@ class DashboardController(
                 .addTo(modelList)
         }
 
-        if ((ownHealthStatus is HealthStatusData.SelfTestingSuspicionOfSickness ||
-                ownHealthStatus is HealthStatusData.SicknessCertificate) &&
-            uploadMissingExposureKeys.isPresent
-        ) {
+        val healthStatusDataMatches =
+            ownHealthStatus is HealthStatusData.SelfTestingSuspicionOfSickness ||
+            ownHealthStatus is HealthStatusData.SicknessCertificate
+
+        if (healthStatusDataMatches && uploadMissingExposureKeys.isPresent) {
             EmptySpaceModel_()
                 .id(modelCountBuiltSoFar)
                 .height(16)

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardFragment.kt
@@ -155,8 +155,9 @@ class DashboardFragment : BaseFragment(R.layout.fragment_dashboard) {
                     ).show()
                 } else {
                     startReportingActivity(
-                        uploadMissingExposureKeys.messageType,
-                        uploadMissingExposureKeys.date
+                        messageType = uploadMissingExposureKeys.messageType,
+                        dateWithMissingExposureKeys = uploadMissingExposureKeys.date,
+                        displayUploadYesterdaysKeysExplanation = true
                     )
                 }
             }
@@ -237,7 +238,7 @@ class DashboardFragment : BaseFragment(R.layout.fragment_dashboard) {
         disposables += viewModel.observeIfUploadOfMissingExposureKeysIsNeeded()
             .observeOnMainThread()
             .subscribe {
-                controller.uploadMissingExposureKeys = it
+                controller.uploadMissingExposureKeys = it.orElse(null)
             }
 
         disposables += viewModel.observeCurrentChangelogState()

--- a/app/src/main/java/at/roteskreuz/stopcorona/utils/DateTimeExtensions.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/utils/DateTimeExtensions.kt
@@ -244,3 +244,7 @@ fun Instant.plusDays(days: Long): Instant = plus(days, ChronoUnit.DAYS)
  * Provides method known from ZonedDateTime
  */
 fun Instant.minusDays(days: Long): Instant = minus(days, ChronoUnit.DAYS)
+
+fun ZonedDateTime.millisUntilTheStartOfTheNextUtcDay(): Long {
+    return (ZonedDateTime.now().plusDays(1).startOfTheUtcDay() - this).toMillis()
+}

--- a/app/src/main/java/at/roteskreuz/stopcorona/utils/DateTimeExtensions.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/utils/DateTimeExtensions.kt
@@ -246,5 +246,5 @@ fun Instant.plusDays(days: Long): Instant = plus(days, ChronoUnit.DAYS)
 fun Instant.minusDays(days: Long): Instant = minus(days, ChronoUnit.DAYS)
 
 fun ZonedDateTime.millisUntilTheStartOfTheNextUtcDay(): Long {
-    return (ZonedDateTime.now().plusDays(1).startOfTheUtcDay() - this).toMillis()
+    return (this.plusDays(1).startOfTheUtcDay() - this).toMillis()
 }

--- a/app/src/main/res/menu/debug.xml
+++ b/app/src/main/res/menu/debug.xml
@@ -43,6 +43,9 @@
                     <item
                         android:id="@+id/debugMenuReportPositiveSelfDiagnose"
                         android:title="Outgoing Yellow" />
+                    <item
+                        android:id="@+id/debugMenuReportYesterdayKey"
+                        android:title="Fake a report from yesterday" />
                 </menu>
             </item>
             <item

--- a/app/src/main/res/menu/debug.xml
+++ b/app/src/main/res/menu/debug.xml
@@ -28,6 +28,9 @@
                     <item
                         android:id="@+id/debugMenuNotificationEndQuarantine"
                         android:title="End of quarantine" />
+                    <item
+                        android:id="@+id/debugMenuNotificationUploadKeys"
+                        android:title="Upload Keys from yesterday" />
                 </menu>
             </item>
             <item

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -435,9 +435,8 @@
 	<string name="local_notification_automatic_handshake_message">Vielen Dank, dass Sie uns bei der Eindämmung des Coronavirus helfen.</string>
 	<string name="local_notification_activate_automatic_handshake_again_title">Bitte aktivieren Sie den automatischen Handshake wieder</string>
 	<string name="local_notification_activate_automatic_handshake_again_message">Und helfen Sie weiter bei der Eindämmung des Coronavirus.</string>
-	<string name="upload_missing_keys">Neue Kontakte benachrichtigen</string>
-	<string name="upload_missing_keys_notification_title">Neue Kontakte benachrichtigen</string>
-	<string name="upload_missing_keys_notification_message">Benachrichtigen Sie Personen, mit denen Sie seit Ihrer letzten Meldung einen digitalen Handshake ausgetauscht haben.</string>
+	<string name="upload_missing_keys_notification_title">Weitere Kontakte benachrichtigen</string>
+	<string name="upload_missing_keys_notification_message">Benachrichtigen Sie Personen, mit denen Sie am Tag Ihrer Meldung einen digitalen Handshake ausgetauscht haben.</string>
 
 	<!-- Contacts Health Status Info -->
 	<string name="contacts_confirmed_one_case_headline">Achtung</string>
@@ -501,6 +500,9 @@
 	<string name="changelog_description_1_v2.0.0">Wir nutzen in dieser Version die</string>
 	<string name="changelog_description_2_v2.0.0">Apple und Google COVID-19 Schnittstelle</string>
 	<string name="changelog_description_3_v2.0.0">. Die Benachrichtigungen werden weiterhin anonym ausgetauscht und es werden daher an ein paar Stellen die Informationen anders dargestellt.\n\nBegegnungen, die Sie vor dem Update auf diese Version als Handshake gespeichert haben, sind aus technischen Gründen nicht mehr gespeichert und können leider nicht mehr benachrichtigt werden.</string>
+	<string name="upload_keys_from_yesterday_title">Kontakte von gestern über ihre Krankmeldung informieren</string>
+	<string name="upload_keys_from_yesterday_message">Benachrichtigen Sie jetzt Kontakte von gestern. Teilen Sie dafür jetzt die IDs aus dem Kontaktprotokoll Ihres Gerätes mit der Stopp Corona App\n\nDas Melden ist weiterhin freiwillig.</string>
+	<string name="upload_keys_from_yesterday_button_title">Jetzt IDs teilen</string>
 	<string name="handshake_code_00">Meise</string>
 	<string name="handshake_code_01">Tukan</string>
 	<string name="handshake_code_02">Gämse</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -10,6 +10,7 @@
 	<string name="general_self_recovered_channel_name">Einige haben Bekanntmachungen wiederhergestellt</string>
 	<string name="general_self_quarantine_channel_name">Quarantänemitteilungen</string>
 	<string name="general_automatic_bt_detection_channel_name">Automatische Benachrichtigungen zur Erkennung von Bluetooth-Geräten</string>
+	<string name="general_uploading_keys_channel_name">Hinweise zur Hochladen der eigenen Schlüssel</string>
 	<string name="general_continue">Weiter</string>
 	<string name="general_additional_information">Weitere Informationen</string>
 
@@ -435,6 +436,8 @@
 	<string name="local_notification_activate_automatic_handshake_again_title">Bitte aktivieren Sie den automatischen Handshake wieder</string>
 	<string name="local_notification_activate_automatic_handshake_again_message">Und helfen Sie weiter bei der Eindämmung des Coronavirus.</string>
 	<string name="upload_missing_keys">Neue Kontakte benachrichtigen</string>
+	<string name="upload_missing_keys_notification_title">Neue Kontakte benachrichtigen</string>
+	<string name="upload_missing_keys_notification_message">Benachrichtigen Sie Personen, mit denen Sie seit Ihrer letzten Meldung einen digitalen Handshake ausgetauscht haben.</string>
 
 	<!-- Contacts Health Status Info -->
 	<string name="contacts_confirmed_one_case_headline">Achtung</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -128,7 +128,7 @@
 	<string name="infection_info_handshake_took_place_format">%s, between %s and %s o`clock</string>
 	<string name="infection_info_go_to_quarantine">Self-quarantine immediately</string>
 	<string name="infection_info_quarantine_end">Please stay quarantined until %s</string>
-	<string name="contact_sickness_guidelines_quarantine_rule">"If you have an official quarantine notification, please take into account the quarantine period specified in the official quarantine notification is."</string>
+	<string name="contact_sickness_guidelines_quarantine_rule">If you have an official quarantine notification, please take into account the quarantine period specified in the official quarantine notification.</string>
 	<string name="infection_info_no_public_transport">Do not use public transport on your way and avoid contact with other people if possible.</string>
 
 	<!-- Contact Sickness_Guidelines for people with probably sick contact -->
@@ -146,7 +146,7 @@
 	<string name="contact_sickness__warning_guidelines_quarantine_rule">If you have an official quarantine certificate, take into account the quarantine period specified in it.</string>
 	<string name="infection_info_warning_no_public_transport">Do not use public transport on your way and avoid contact with other people if possible.</string>
 	<string name="infection_info_confirmed_and_suspicion_title">Attention</string>
-	<string name="infection_info_confirmed_and_suspicion_headline">Coronavirus Disease and suspicion</string>
+	<string name="infection_info_confirmed_and_suspicion_headline">Coronavirus disease and suspicion</string>
 
 	<!-- Handshake -->
 	<string name="handshake_title">Digital handshake</string>
@@ -435,9 +435,8 @@
 	<string name="local_notification_automatic_handshake_message">Thank you for helping us contain the Corona virus.</string>
 	<string name="local_notification_activate_automatic_handshake_again_title">Please activate the automatic handshake again</string>
 	<string name="local_notification_activate_automatic_handshake_again_message">and continue to help contain the corona virus.</string>
-	<string name="upload_missing_keys">Notify new contacts</string>
-	<string name="upload_missing_keys_notification_title">Notify new contacts</string>
-	<string name="upload_missing_keys_notification_message">Notify people with whom you have exchanged a digital handshake since your last message.</string>
+	<string name="upload_missing_keys_notification_title">Notify other contacts</string>
+	<string name="upload_missing_keys_notification_message">Notify people with whom you exchanged a digital handshake on the day you reported sick.</string>
 
 	<!-- Contacts Health Status Info -->
 	<string name="contacts_confirmed_one_case_headline">Caution</string>
@@ -501,6 +500,9 @@
 	<string name="changelog_description_1_v2.0.0">In this version we use the</string>
 	<string name="changelog_description_2_v2.0.0">Apple and Google COVID-19 interface</string>
 	<string name="changelog_description_3_v2.0.0">. The notifications will continue to be exchanged anonymously and therefore in some places the information will be presented differently.\n\nEncounters that you saved as a handshake before updating to this version are no longer saved for technical reasons and can unfortunately no longer be notified.\n</string>
+	<string name="upload_keys_from_yesterday_title">Notify contacts that occured yesterday</string>
+	<string name="upload_keys_from_yesterday_message">Please upload your ID from yesterday. Sharing this ID is still voluntarely.</string>
+	<string name="upload_keys_from_yesterday_button_title">Share IDs now</string>
 	<string name="handshake_code_00">Meise</string>
 	<string name="handshake_code_01">Tukan</string>
 	<string name="handshake_code_02">Gämse</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
 	<string name="general_self_recovered_channel_name">Some has recovered notices</string>
 	<string name="general_self_quarantine_channel_name">Quarantine notices</string>
 	<string name="general_automatic_bt_detection_channel_name">Automatic Bluetooth device detection notices</string>
-	<string name="general_uploading_keys_channel_name">Notices gerarding the uploading of your owm keys</string>
+	<string name="general_uploading_keys_channel_name">Notices regarding the uploading of your own keys</string>
 	<string name="general_continue">Continue</string>
 	<string name="general_additional_information">Further information</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
 	<string name="general_self_recovered_channel_name">Some has recovered notices</string>
 	<string name="general_self_quarantine_channel_name">Quarantine notices</string>
 	<string name="general_automatic_bt_detection_channel_name">Automatic Bluetooth device detection notices</string>
+	<string name="general_uploading_keys_channel_name">Notices gerarding the uploading of your owm keys</string>
 	<string name="general_continue">Continue</string>
 	<string name="general_additional_information">Further information</string>
 
@@ -435,6 +436,8 @@
 	<string name="local_notification_activate_automatic_handshake_again_title">Please activate the automatic handshake again</string>
 	<string name="local_notification_activate_automatic_handshake_again_message">and continue to help contain the corona virus.</string>
 	<string name="upload_missing_keys">Notify new contacts</string>
+	<string name="upload_missing_keys_notification_title">Notify new contacts</string>
+	<string name="upload_missing_keys_notification_message">Notify people with whom you have exchanged a digital handshake since your last message.</string>
 
 	<!-- Contacts Health Status Info -->
 	<string name="contacts_confirmed_one_case_headline">Caution</string>

--- a/app/src/test/java/at/roteskreuz/stopcorona/model/entities/session/DbFullBatchPartTest.kt
+++ b/app/src/test/java/at/roteskreuz/stopcorona/model/entities/session/DbFullBatchPartTest.kt
@@ -5,7 +5,7 @@ import org.junit.Test
 class DbFullBatchPartTest {
 
     @Test
-    fun testSomeSorting() {
+    fun `just a random test to make sure sortedBy sorts ascending`() {
         val part1 = DbFullBatchPart(
             sessionId = 1,
             batchNumber = 1,

--- a/app/src/test/java/at/roteskreuz/stopcorona/model/entities/session/DbFullBatchPartTest.kt
+++ b/app/src/test/java/at/roteskreuz/stopcorona/model/entities/session/DbFullBatchPartTest.kt
@@ -5,7 +5,7 @@ import org.junit.Test
 class DbFullBatchPartTest {
 
     @Test
-    fun getIntervalStart() {
+    fun testSomeSorting() {
         val part1 = DbFullBatchPart(
             sessionId = 1,
             batchNumber = 1,

--- a/app/src/test/java/at/roteskreuz/stopcorona/model/repositories/QuarantineStatusTest.kt
+++ b/app/src/test/java/at/roteskreuz/stopcorona/model/repositories/QuarantineStatusTest.kt
@@ -18,7 +18,7 @@ import org.threeten.bp.ZonedDateTime
 class QuarantineStatusTest {
 
     @Test
-    fun testDaysUntilTodayToBeOne(){
+    fun `days until end of quarantine today needs to be 1`(){
         val endsToday = ZonedDateTime.now().plusHours(1)
         val limited = QuarantineStatus.Jailed.Limited(end = endsToday, byContact = true)
 
@@ -26,7 +26,7 @@ class QuarantineStatusTest {
     }
 
     @Test
-    fun testDaysUntilSevenDaysToBeEight(){
+    fun `7 days of quarantine actually show as 8 days`(){
         val endsToday = ZonedDateTime.now().plusDays(7)
         val limited = QuarantineStatus.Jailed.Limited(end = endsToday, byContact = true)
 

--- a/app/src/test/java/at/roteskreuz/stopcorona/utils/DateTimeExtensionsKtTest.kt
+++ b/app/src/test/java/at/roteskreuz/stopcorona/utils/DateTimeExtensionsKtTest.kt
@@ -9,7 +9,7 @@ import org.threeten.bp.ZonedDateTime
 class DateTimeExtensionsKtTest {
 
     @Test
-    fun millisUntilTheStartOfTheNextUtcDay() {
+    fun `test milliseconds calculation to the next UTC day`() {
 
         val todayNoon: ZonedDateTime = ZonedDateTime.now()
             .withZoneSameLocal(ZoneId.of("UTC+2"))

--- a/app/src/test/java/at/roteskreuz/stopcorona/utils/DateTimeExtensionsKtTest.kt
+++ b/app/src/test/java/at/roteskreuz/stopcorona/utils/DateTimeExtensionsKtTest.kt
@@ -1,0 +1,24 @@
+package at.roteskreuz.stopcorona.utils
+
+import org.junit.Test
+
+import org.junit.Assert.*
+import org.threeten.bp.ZoneId
+import org.threeten.bp.ZonedDateTime
+
+class DateTimeExtensionsKtTest {
+
+    @Test
+    fun millisUntilTheStartOfTheNextUtcDay() {
+
+        val todayNoon: ZonedDateTime = ZonedDateTime.now()
+            .withZoneSameLocal(ZoneId.of("UTC+2"))
+            .withHour(12)
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0)
+        // 12 hours + 2 hours offset 
+        assertEquals((12+2)*60*60*1000,todayNoon.millisUntilTheStartOfTheNextUtcDay())
+
+    }
+}

--- a/app/src/test/java/at/roteskreuz/stopcorona/utils/ExposureNotficationExtensionsKtTest.kt
+++ b/app/src/test/java/at/roteskreuz/stopcorona/utils/ExposureNotficationExtensionsKtTest.kt
@@ -31,7 +31,7 @@ class ExposureNotficationExtensionsKtTest {
         .build()
 
     @Test
-    fun testEmpty() {
+    fun `no exposures lead to no exposure dates`() {
         val listUnderTest: List<ExposureInformation> = emptyList()
 
         val dates = listUnderTest.extractLatestRedAndYellowContactDate(THRESHOLD)
@@ -41,7 +41,7 @@ class ExposureNotficationExtensionsKtTest {
     }
 
     @Test
-    fun ignoreSingleUnriskyYellow() {
+    fun `a single yellow exposure information leads to a the yellow date on that day`() {
         val listUnderTest: List<ExposureInformation> = arrayListOf(SHORT_YELLOW_TWO_DAYS_AGO)
 
         val dates = listUnderTest.extractLatestRedAndYellowContactDate(THRESHOLD)
@@ -51,7 +51,7 @@ class ExposureNotficationExtensionsKtTest {
     }
 
     @Test
-    fun twoUnriskyTriggerYellowWarning() {
+    fun `two individual yellow exposures, individually not relevant must lead to a combined yellow warning`() {
         val listUnderTest: List<ExposureInformation> = arrayListOf(SHORT_YELLOW_TWO_DAYS_AGO, SHORT_YELLOW_TWO_DAYS_AGO)
 
         val dates = listUnderTest.extractLatestRedAndYellowContactDate(THRESHOLD)
@@ -62,7 +62,7 @@ class ExposureNotficationExtensionsKtTest {
     }
 
     @Test
-    fun detectSimpleRed() {
+    fun `detect a single red exposure day`() {
 
         val listUnderTest: List<ExposureInformation> = arrayListOf(RED_YESTERDAY)
 
@@ -74,7 +74,7 @@ class ExposureNotficationExtensionsKtTest {
     }
 
     @Test
-    fun detectTwoRed_detectLatest_orderIrrelevant() {
+    fun `detect the latest red day irrelevant of the order of the exposures in the list of exposures`() {
 
         val listUnderTest: List<ExposureInformation> = arrayListOf(RED_TWO_DAYS_AGO, RED_YESTERDAY)
         val listUnderTest2: List<ExposureInformation> = arrayListOf(RED_YESTERDAY, RED_YESTERDAY)

--- a/core/src/main/java/at/roteskreuz/stopcorona/skeleton/core/screens/base/activity/BaseActivity.kt
+++ b/core/src/main/java/at/roteskreuz/stopcorona/skeleton/core/screens/base/activity/BaseActivity.kt
@@ -9,7 +9,9 @@ import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.NavUtils
 import androidx.core.app.TaskStackBuilder
+import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import at.roteskreuz.stopcorona.skeleton.core.R
 import at.roteskreuz.stopcorona.skeleton.core.screens.base.fragment.BaseFragment
@@ -141,6 +143,10 @@ open class BaseActivity(@LayoutRes private val layout: Int = R.layout.framelayou
                 navigateUp()
             } else super.onBackPressed()
         }
+    }
+
+    inline fun <reified T : DialogFragment> T.show(fragmentManager: FragmentManager = supportFragmentManager) {
+        show(fragmentManager, T::class.java.name)
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
## Changes

- [x] notification for uploading yesterdays keys (#192)
- [x] introduce new screen with explanation (https://github.com/austrianredcross/stopp-corona-android/pull/196)
- [x] fix notification target to new screen (https://github.com/austrianredcross/stopp-corona-android/pull/196)


## Solved issues

- [Issue #1691](https://tasks.pxp-x.com/browse/CTAA-1691)
