### PR TITLE
Fix/ctaa 1691 explanation screen

### DIFF
--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/base/CoronaBaseActivity.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/base/CoronaBaseActivity.kt
@@ -74,6 +74,10 @@ open class CoronaBaseActivity(@LayoutRes layout: Int = R.layout.framelayout) : B
                 debugViewModel.reportPositiveSelfDiagnose()
                 true
             }
+            R.id.debugMenuReportYesterdayKey -> {
+                debugViewModel.fakeReportWithMissingKeysYesterday()
+                true
+            }
             R.id.debugExposureNotifications -> {
                 startDebugExposureNotificationsFragment()
                 true

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/base/DebugViewModel.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/base/DebugViewModel.kt
@@ -8,6 +8,7 @@ import at.roteskreuz.stopcorona.skeleton.core.screens.base.viewmodel.ScopedViewM
 import at.roteskreuz.stopcorona.utils.minusDays
 import kotlinx.coroutines.launch
 import org.threeten.bp.Instant
+import org.threeten.bp.ZonedDateTime
 
 /**
  * Special viewModel for managing debug tasks.
@@ -85,5 +86,10 @@ class DebugViewModel(
 
     fun displayNotificationForUploadingKeysFromTheDayBefore() {
         notificationsRepository.displayNotificationForUploadingKeysFromTheDayBefore()
+    }
+
+    fun fakeReportWithMissingKeysYesterday() {
+        quarantineRepository.markMissingExposureKeysAsNotUploaded()
+        quarantineRepository.reportMedicalConfirmation(ZonedDateTime.now().minusDays(1))
     }
 }

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardController.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardController.kt
@@ -20,7 +20,6 @@ import at.roteskreuz.stopcorona.utils.startOfTheDay
 import at.roteskreuz.stopcorona.utils.string
 import com.airbnb.epoxy.EpoxyController
 import com.airbnb.epoxy.EpoxyModel
-import com.github.dmstocking.optional.java.util.Optional
 import org.threeten.bp.ZonedDateTime
 
 /**
@@ -50,7 +49,7 @@ class DashboardController(
     var someoneHasRecoveredHealthStatus: HealthStatusData by adapterProperty(HealthStatusData.NoHealthStatus)
     var exposureNotificationPhase: ExposureNotificationPhase? by adapterProperty(null as ExposureNotificationPhase?)
     var dateOfFirstMedicalConfirmation: ZonedDateTime? by adapterProperty(null as ZonedDateTime?)
-    var uploadMissingExposureKeys: Optional<UploadMissingExposureKeys> by adapterProperty(Optional.empty())
+    var uploadMissingExposureKeys: UploadMissingExposureKeys? by adapterProperty(null as UploadMissingExposureKeys?)
 
     override fun buildModels() {
         emptySpace(modelCountBuiltSoFar, 16)
@@ -453,9 +452,10 @@ class DashboardController(
 
         val healthStatusDataMatches =
             ownHealthStatus is HealthStatusData.SelfTestingSuspicionOfSickness ||
-            ownHealthStatus is HealthStatusData.SicknessCertificate
+                ownHealthStatus is HealthStatusData.SicknessCertificate
 
-        if (healthStatusDataMatches && uploadMissingExposureKeys.isPresent) {
+        val uploadMissingExposureKeys = uploadMissingExposureKeys
+        if (healthStatusDataMatches && uploadMissingExposureKeys != null) {
             EmptySpaceModel_()
                 .id(modelCountBuiltSoFar)
                 .height(16)
@@ -464,16 +464,16 @@ class DashboardController(
             ButtonType2Model_ {
                 onUploadMissingExposureKeysClick(
                     false,
-                    uploadMissingExposureKeys.get()
+                    uploadMissingExposureKeys
                 )
             }
                 .id("own_health_status_upload_missing_exposure_keys")
-                .text(context.string(R.string.upload_missing_keys))
+                .text(context.string(R.string.upload_missing_keys_notification_title))
                 .enabled(exposureNotificationPhase.isReportingEnabled())
                 .onDisabledClick {
                     onUploadMissingExposureKeysClick(
                         true,
-                        uploadMissingExposureKeys.get()
+                        uploadMissingExposureKeys
                     )
                 }
                 .addTo(modelList)

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardController.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardController.kt
@@ -1,6 +1,7 @@
 package at.roteskreuz.stopcorona.screens.dashboard
 
 import android.content.Context
+import android.text.SpannableString
 import at.roteskreuz.stopcorona.R
 import at.roteskreuz.stopcorona.constants.Constants
 import at.roteskreuz.stopcorona.model.managers.ExposureNotificationPhase
@@ -461,14 +462,24 @@ class DashboardController(
                 .height(16)
                 .addTo(modelList)
 
+            CopyTextModel_()
+                .id("own_health_status_upload_missing_exposure_keys_explanation")
+                .text(SpannableString(context.string(R.string.self_testing_symptoms_warning_info_update)))
+                .addTo(modelList)
+
+            EmptySpaceModel_()
+                .id(modelCountBuiltSoFar)
+                .height(16)
+                .addTo(modelList)
+
             ButtonType2Model_ {
                 onUploadMissingExposureKeysClick(
                     false,
                     uploadMissingExposureKeys
                 )
             }
-                .id("own_health_status_upload_missing_exposure_keys")
-                .text(context.string(R.string.upload_missing_keys_notification_title))
+                .id("own_health_status_upload_missing_exposure_keys_button")
+                .text(context.string(R.string.self_testing_symptoms_warning_button_update))
                 .enabled(exposureNotificationPhase.isReportingEnabled())
                 .onDisabledClick {
                     onUploadMissingExposureKeysClick(

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardFragment.kt
@@ -155,8 +155,9 @@ class DashboardFragment : BaseFragment(R.layout.fragment_dashboard) {
                     ).show()
                 } else {
                     startReportingActivity(
-                        uploadMissingExposureKeys.messageType,
-                        uploadMissingExposureKeys.date
+                        messageType = uploadMissingExposureKeys.messageType,
+                        dateWithMissingExposureKeys = uploadMissingExposureKeys.date,
+                        displayUploadYesterdaysKeysExplanation = true
                     )
                 }
             }
@@ -237,7 +238,7 @@ class DashboardFragment : BaseFragment(R.layout.fragment_dashboard) {
         disposables += viewModel.observeIfUploadOfMissingExposureKeysIsNeeded()
             .observeOnMainThread()
             .subscribe {
-                controller.uploadMissingExposureKeys = it
+                controller.uploadMissingExposureKeys = it.orElse(null)
             }
 
         disposables += viewModel.observeCurrentChangelogState()

--- a/app/src/main/res/menu/debug.xml
+++ b/app/src/main/res/menu/debug.xml
@@ -43,6 +43,9 @@
                     <item
                         android:id="@+id/debugMenuReportPositiveSelfDiagnose"
                         android:title="Outgoing Yellow" />
+                    <item
+                        android:id="@+id/debugMenuReportYesterdayKey"
+                        android:title="Fake a report from yesterday" />
                 </menu>
             </item>
             <item

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -435,9 +435,8 @@
 	<string name="local_notification_automatic_handshake_message">Vielen Dank, dass Sie uns bei der Eindämmung des Coronavirus helfen.</string>
 	<string name="local_notification_activate_automatic_handshake_again_title">Bitte aktivieren Sie den automatischen Handshake wieder</string>
 	<string name="local_notification_activate_automatic_handshake_again_message">Und helfen Sie weiter bei der Eindämmung des Coronavirus.</string>
-	<string name="upload_missing_keys">Neue Kontakte benachrichtigen</string>
-	<string name="upload_missing_keys_notification_title">Neue Kontakte benachrichtigen</string>
-	<string name="upload_missing_keys_notification_message">Benachrichtigen Sie Personen, mit denen Sie seit Ihrer letzten Meldung einen digitalen Handshake ausgetauscht haben.</string>
+	<string name="upload_missing_keys_notification_title">Weitere Kontakte benachrichtigen</string>
+	<string name="upload_missing_keys_notification_message">Benachrichtigen Sie Personen, mit denen Sie am Tag Ihrer Meldung einen digitalen Handshake ausgetauscht haben.</string>
 
 	<!-- Contacts Health Status Info -->
 	<string name="contacts_confirmed_one_case_headline">Achtung</string>
@@ -501,6 +500,9 @@
 	<string name="changelog_description_1_v2.0.0">Wir nutzen in dieser Version die</string>
 	<string name="changelog_description_2_v2.0.0">Apple und Google COVID-19 Schnittstelle</string>
 	<string name="changelog_description_3_v2.0.0">. Die Benachrichtigungen werden weiterhin anonym ausgetauscht und es werden daher an ein paar Stellen die Informationen anders dargestellt.\n\nBegegnungen, die Sie vor dem Update auf diese Version als Handshake gespeichert haben, sind aus technischen Gründen nicht mehr gespeichert und können leider nicht mehr benachrichtigt werden.</string>
+	<string name="upload_keys_from_yesterday_title">Kontakte von gestern über ihre Krankmeldung informieren</string>
+	<string name="upload_keys_from_yesterday_message">Benachrichtigen Sie jetzt Kontakte von gestern. Teilen Sie dafür jetzt die IDs aus dem Kontaktprotokoll Ihres Gerätes mit der Stopp Corona App\n\nDas Melden ist weiterhin freiwillig.</string>
+	<string name="upload_keys_from_yesterday_button_title">Jetzt IDs teilen</string>
 	<string name="handshake_code_00">Meise</string>
 	<string name="handshake_code_01">Tukan</string>
 	<string name="handshake_code_02">Gämse</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -128,7 +128,7 @@
 	<string name="infection_info_handshake_took_place_format">%s, between %s and %s o`clock</string>
 	<string name="infection_info_go_to_quarantine">Self-quarantine immediately</string>
 	<string name="infection_info_quarantine_end">Please stay quarantined until %s</string>
-	<string name="contact_sickness_guidelines_quarantine_rule">"If you have an official quarantine notification, please take into account the quarantine period specified in the official quarantine notification is."</string>
+	<string name="contact_sickness_guidelines_quarantine_rule">If you have an official quarantine notification, please take into account the quarantine period specified in the official quarantine notification.</string>
 	<string name="infection_info_no_public_transport">Do not use public transport on your way and avoid contact with other people if possible.</string>
 
 	<!-- Contact Sickness_Guidelines for people with probably sick contact -->
@@ -146,7 +146,7 @@
 	<string name="contact_sickness__warning_guidelines_quarantine_rule">If you have an official quarantine certificate, take into account the quarantine period specified in it.</string>
 	<string name="infection_info_warning_no_public_transport">Do not use public transport on your way and avoid contact with other people if possible.</string>
 	<string name="infection_info_confirmed_and_suspicion_title">Attention</string>
-	<string name="infection_info_confirmed_and_suspicion_headline">Coronavirus Disease and suspicion</string>
+	<string name="infection_info_confirmed_and_suspicion_headline">Coronavirus disease and suspicion</string>
 
 	<!-- Handshake -->
 	<string name="handshake_title">Digital handshake</string>
@@ -435,9 +435,8 @@
 	<string name="local_notification_automatic_handshake_message">Thank you for helping us contain the Corona virus.</string>
 	<string name="local_notification_activate_automatic_handshake_again_title">Please activate the automatic handshake again</string>
 	<string name="local_notification_activate_automatic_handshake_again_message">and continue to help contain the corona virus.</string>
-	<string name="upload_missing_keys">Notify new contacts</string>
-	<string name="upload_missing_keys_notification_title">Notify new contacts</string>
-	<string name="upload_missing_keys_notification_message">Notify people with whom you have exchanged a digital handshake since your last message.</string>
+	<string name="upload_missing_keys_notification_title">Notify other contacts</string>
+	<string name="upload_missing_keys_notification_message">Notify people with whom you exchanged a digital handshake on the day you reported sick.</string>
 
 	<!-- Contacts Health Status Info -->
 	<string name="contacts_confirmed_one_case_headline">Caution</string>
@@ -501,6 +500,9 @@
 	<string name="changelog_description_1_v2.0.0">In this version we use the</string>
 	<string name="changelog_description_2_v2.0.0">Apple and Google COVID-19 interface</string>
 	<string name="changelog_description_3_v2.0.0">. The notifications will continue to be exchanged anonymously and therefore in some places the information will be presented differently.\n\nEncounters that you saved as a handshake before updating to this version are no longer saved for technical reasons and can unfortunately no longer be notified.\n</string>
+	<string name="upload_keys_from_yesterday_title">Notify contacts that occured yesterday</string>
+	<string name="upload_keys_from_yesterday_message">Please upload your ID from yesterday. Sharing this ID is still voluntarely.</string>
+	<string name="upload_keys_from_yesterday_button_title">Share IDs now</string>
 	<string name="handshake_code_00">Meise</string>
 	<string name="handshake_code_01">Tukan</string>
 	<string name="handshake_code_02">Gämse</string>

--- a/core/src/main/java/at/roteskreuz/stopcorona/skeleton/core/screens/base/activity/BaseActivity.kt
+++ b/core/src/main/java/at/roteskreuz/stopcorona/skeleton/core/screens/base/activity/BaseActivity.kt
@@ -9,7 +9,9 @@ import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.NavUtils
 import androidx.core.app.TaskStackBuilder
+import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import at.roteskreuz.stopcorona.skeleton.core.R
 import at.roteskreuz.stopcorona.skeleton.core.screens.base.fragment.BaseFragment
@@ -141,6 +143,10 @@ open class BaseActivity(@LayoutRes private val layout: Int = R.layout.framelayou
                 navigateUp()
             } else super.onBackPressed()
         }
+    }
+
+    inline fun <reified T : DialogFragment> T.show(fragmentManager: FragmentManager = supportFragmentManager) {
+        show(fragmentManager, T::class.java.name)
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
## Changes

Introduced new dialog with explanation of reupload yesterdays keys.
Fixed notification target to reporting screen with explanation dialog

## Solved issues

sub task of
- [Issue #1691](https://tasks.pxp-x.com/browse/CTAA-1691)
