### PR TITLE
CTAA-1120: Do not show quarantine days if quarantine end is in the past

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -138,7 +138,9 @@ dependencies {
 
     kapt "androidx.room:room-compiler:2.2.4"
 
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.3.7"
+    def coroutinesVserion = "1.3.7"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$coroutinesVserion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:$coroutinesVserion"
 
     implementation "androidx.constraintlayout:constraintlayout:1.1.3"
     implementation "androidx.cardview:cardview:1.0.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -138,9 +138,9 @@ dependencies {
 
     kapt "androidx.room:room-compiler:2.2.4"
 
-    def coroutinesVserion = "1.3.7"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$coroutinesVserion"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:$coroutinesVserion"
+    def coroutinesVersion = "1.3.7"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$coroutinesVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:$coroutinesVersion"
 
     implementation "androidx.constraintlayout:constraintlayout:1.1.3"
     implementation "androidx.cardview:cardview:1.0.0"

--- a/app/src/main/java/at/roteskreuz/stopcorona/di/RepositoryModule.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/di/RepositoryModule.kt
@@ -71,7 +71,6 @@ val repositoryModule = module {
 
     single<QuarantineRepository> {
         QuarantineRepositoryImpl(
-            appDispatchers = get(),
             preferences = get(),
             configurationRepository = get(),
             workManager = get()

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/QuarantineRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/QuarantineRepository.kt
@@ -518,10 +518,12 @@ sealed class QuarantineStatus {
         data class Limited(val end: ZonedDateTime, val byContact: Boolean) : Jailed() {
 
             /**
-             * number if days displayed to the user until he is off quarantine (we add one to account for the offset on the last day)
+             * Number of days displayed to the user until he is off quarantine (we add one to account for the offset on the last day)
              */
             fun daysUntilEnd(): Long {
-                return this.end.toLocalDate().daysTo(ZonedDateTime.now().startOfTheDay().toLocalDate()) + 1
+                val today = ZonedDateTime.now().startOfTheDay().toLocalDate()
+                val endDate = this.end.toLocalDate()
+                return today.daysTo(endDate) + 1
             }
         }
 

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/QuarantineRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/QuarantineRepository.kt
@@ -12,10 +12,7 @@ import at.roteskreuz.stopcorona.model.workers.SelfRetestNotifierWorker.Companion
 import at.roteskreuz.stopcorona.model.workers.SelfRetestNotifierWorker.Companion.enqueueSelfRetestingReminder
 import at.roteskreuz.stopcorona.skeleton.core.model.helpers.AppDispatchers
 import at.roteskreuz.stopcorona.skeleton.core.utils.*
-import at.roteskreuz.stopcorona.utils.afterOrNull
-import at.roteskreuz.stopcorona.utils.areOnTheSameUtcDay
-import at.roteskreuz.stopcorona.utils.daysTo
-import at.roteskreuz.stopcorona.utils.endOfTheUtcDay
+import at.roteskreuz.stopcorona.utils.*
 import at.roteskreuz.stopcorona.utils.view.safeMap
 import com.github.dmstocking.optional.java.util.Optional
 import io.reactivex.Observable
@@ -257,6 +254,7 @@ class QuarantineRepositoryImpl(
         }
         // don't notify again if nothing has changed
         .distinctUntilChanged()
+        .shareReplayLast()
 
     init {
         var oldState: QuarantineStatus? = null
@@ -271,13 +269,6 @@ class QuarantineRepositoryImpl(
             updateNotifications(newState)
         }
     }
-
-    private val QuarantinePrerequisitesHolder.l: Long
-        get() {
-            val redWarningQuarantinedHours = configuration.redWarningQuarantine?.toLong()
-                .safeMap("redWarningQuarantine is null", defaultValue = TimeUnit.DAYS.toHours(14L))
-            return redWarningQuarantinedHours
-        }
 
     /**
      * Logic of making quarantine status by prerequisites.

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/QuarantineRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/QuarantineRepository.kt
@@ -307,7 +307,7 @@ class QuarantineRepositoryImpl(
                 val quarantinedUntil = listOfNotNull(redWarningQuarantineUntil, yellowWarningQuarantineUntil, selfDiagnoseQuarantineUntil)
                     .max()
 
-                if (quarantinedUntil != null) {
+                if (quarantinedUntil != null && quarantinedUntil.isAfter(ZonedDateTime.now())) {
                     QuarantineStatus.Jailed.Limited(quarantinedUntil,
                         (redContactLastDateTime != null || yellowContactLastDateTime != null) && selfDiagnoseLastDateTime == null)
                 } else {

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/QuarantineRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/QuarantineRepository.kt
@@ -10,7 +10,6 @@ import at.roteskreuz.stopcorona.model.workers.EndQuarantineNotifierWorker.Compan
 import at.roteskreuz.stopcorona.model.workers.EndQuarantineNotifierWorker.Companion.enqueueEndQuarantineReminder
 import at.roteskreuz.stopcorona.model.workers.SelfRetestNotifierWorker.Companion.cancelSelfRetestingReminder
 import at.roteskreuz.stopcorona.model.workers.SelfRetestNotifierWorker.Companion.enqueueSelfRetestingReminder
-import at.roteskreuz.stopcorona.skeleton.core.model.helpers.AppDispatchers
 import at.roteskreuz.stopcorona.skeleton.core.utils.*
 import at.roteskreuz.stopcorona.utils.*
 import at.roteskreuz.stopcorona.utils.view.safeMap
@@ -152,7 +151,6 @@ interface QuarantineRepository {
 }
 
 class QuarantineRepositoryImpl(
-    private val appDispatchers: AppDispatchers,
     preferences: SharedPreferences,
     configurationRepository: ConfigurationRepository,
     private val workManager: WorkManager

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/workers/EndQuarantineNotifierWorker.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/workers/EndQuarantineNotifierWorker.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import androidx.work.*
 import at.roteskreuz.stopcorona.model.repositories.NotificationsRepository
 import at.roteskreuz.stopcorona.model.repositories.QuarantineRepository
-import at.roteskreuz.stopcorona.utils.minus
+import at.roteskreuz.stopcorona.utils.millisTo
 import at.roteskreuz.stopcorona.utils.startOfTheDay
 import org.koin.standalone.KoinComponent
 import org.koin.standalone.inject
@@ -28,10 +28,12 @@ class EndQuarantineNotifierWorker(
         fun enqueueEndQuarantineReminder(workManager: WorkManager, endDateTime: ZonedDateTime) {
             // computing end of the quarantine
             // we set the end time as a midnight of the end date
-            val delay = endDateTime.startOfTheDay() - ZonedDateTime.now()
+            val now = ZonedDateTime.now()
+            val endDay = endDateTime.startOfTheDay()
+            val millisBeforeQuarantineEnd = now.millisTo(endDay)
 
             val request = OneTimeWorkRequestBuilder<EndQuarantineNotifierWorker>()
-                .setInitialDelay(delay.toMillis(), TimeUnit.MILLISECONDS)
+                .setInitialDelay(millisBeforeQuarantineEnd, TimeUnit.MILLISECONDS)
                 .addTag(TAG)
                 .build()
 

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/workers/ExposureMatchingWorker.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/workers/ExposureMatchingWorker.kt
@@ -4,10 +4,9 @@ import android.content.Context
 import androidx.work.*
 import at.roteskreuz.stopcorona.model.exceptions.SilentError
 import at.roteskreuz.stopcorona.model.repositories.DiagnosisKeysRepository
-import at.roteskreuz.stopcorona.utils.minus
+import at.roteskreuz.stopcorona.utils.millisTo
 import org.koin.standalone.KoinComponent
 import org.koin.standalone.inject
-import org.threeten.bp.Duration
 import org.threeten.bp.ZonedDateTime
 import timber.log.Timber
 import java.lang.Exception
@@ -32,10 +31,10 @@ class ExposureMatchingWorker(
             val constraints = Constraints.Builder()
                 .setRequiredNetworkType(NetworkType.CONNECTED) // internet access
                 .build()
-
+            val millisUntilNextRun = computeMillisUntilNextRun()
             val request = OneTimeWorkRequestBuilder<ExposureMatchingWorker>()
                 .setConstraints(constraints)
-                .setInitialDelay(computeDelayUntilNextRun().seconds, TimeUnit.SECONDS)
+                .setInitialDelay(millisUntilNextRun, TimeUnit.MILLISECONDS)
                 .addTag(TAG)
                 .build()
 
@@ -61,7 +60,7 @@ class ExposureMatchingWorker(
                     nextPossibleRun
                 }
             }
-            return plannedRun.minus(ZonedDateTime.now())
+            return now.millisTo(plannedRun)
         }
     }
 

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/workers/SelfRetestNotifierWorker.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/workers/SelfRetestNotifierWorker.kt
@@ -31,7 +31,7 @@ class SelfRetestNotifierWorker(
 
             workManager.enqueueUniquePeriodicWork(
                 TAG,
-                ExistingPeriodicWorkPolicy.REPLACE,
+                ExistingPeriodicWorkPolicy.KEEP,
                 request
             )
         }

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/workers/UploadMissingExposureKeysReminderWorker.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/workers/UploadMissingExposureKeysReminderWorker.kt
@@ -6,7 +6,7 @@ import at.roteskreuz.stopcorona.model.exceptions.SilentError
 import at.roteskreuz.stopcorona.model.repositories.NotificationsRepository
 import at.roteskreuz.stopcorona.model.repositories.QuarantineRepository
 import at.roteskreuz.stopcorona.model.repositories.UploadMissingExposureKeys
-import at.roteskreuz.stopcorona.utils.minus
+import at.roteskreuz.stopcorona.utils.millisTo
 import org.koin.standalone.KoinComponent
 import org.koin.standalone.inject
 import org.threeten.bp.ZonedDateTime
@@ -26,11 +26,7 @@ class UploadMissingExposureKeysReminderWorker(
 
         fun enqueueUploadMissingExposureKeysWorker(workManager: WorkManager, reminderTime: ZonedDateTime) {
             val now = ZonedDateTime.now()
-            val millisBeforeReminder = if (reminderTime.isAfter(now)) {
-                reminderTime.minus(now).toMillis()
-            } else {
-                0L
-            }
+            val millisBeforeReminder = now.millisTo(reminderTime)
             val request = OneTimeWorkRequestBuilder<UploadMissingExposureKeysReminderWorker>()
                 .setInitialDelay(millisBeforeReminder, TimeUnit.MILLISECONDS)
                 .build()

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/workers/UploadMissingExposureKeysReminderWorker.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/workers/UploadMissingExposureKeysReminderWorker.kt
@@ -7,6 +7,7 @@ import at.roteskreuz.stopcorona.model.repositories.NotificationsRepository
 import at.roteskreuz.stopcorona.model.repositories.QuarantineRepository
 import at.roteskreuz.stopcorona.model.repositories.UploadMissingExposureKeys
 import at.roteskreuz.stopcorona.utils.millisTo
+import kotlinx.coroutines.rx2.awaitFirst
 import org.koin.standalone.KoinComponent
 import org.koin.standalone.inject
 import org.threeten.bp.ZonedDateTime
@@ -48,7 +49,7 @@ class UploadMissingExposureKeysReminderWorker(
 
     override suspend fun doWork(): Result {
         val uploadMissingExposureKeys: UploadMissingExposureKeys? = quarantineRepository.observeIfUploadOfMissingExposureKeysIsNeeded()
-            .blockingFirst().orElse(null)
+            .awaitFirst().orElse(null)
         if (uploadMissingExposureKeys != null) {
             notificationsRepository.displayNotificationForUploadingMissingExposureKeyse(
                 messageType = uploadMissingExposureKeys.messageType,

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/base/DebugViewModel.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/base/DebugViewModel.kt
@@ -8,6 +8,7 @@ import at.roteskreuz.stopcorona.skeleton.core.model.helpers.AppDispatchers
 import at.roteskreuz.stopcorona.skeleton.core.screens.base.viewmodel.ScopedViewModel
 import at.roteskreuz.stopcorona.utils.minusDays
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.rx2.awaitFirst
 import org.threeten.bp.Instant
 import org.threeten.bp.ZonedDateTime
 import timber.log.Timber
@@ -89,7 +90,7 @@ class DebugViewModel(
     fun displayNotificationForUploadingMissingExposureKeys() {
         launch(appDispatchers.Default) {
             val uploadMissingExposureKeys: UploadMissingExposureKeys? = quarantineRepository.observeIfUploadOfMissingExposureKeysIsNeeded()
-                .blockingFirst().orElse(null)
+                .awaitFirst().orElse(null)
             if (uploadMissingExposureKeys != null) {
                 notificationsRepository.displayNotificationForUploadingMissingExposureKeyse(
                     messageType = uploadMissingExposureKeys.messageType,

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/dashboard/DashboardViewModel.kt
@@ -87,8 +87,8 @@ class DashboardViewModel(
                     is QuarantineStatus.Jailed.Forever -> HealthStatusData.SicknessCertificate
                     is QuarantineStatus.Jailed.Limited -> {
                         when {
-                            quarantineStatus.byContact -> HealthStatusData.NoHealthStatus
-                            else -> HealthStatusData.SelfTestingSuspicionOfSickness(quarantineStatus)
+                            quarantineStatus.bySelfDiagnosis != null -> HealthStatusData.SelfTestingSuspicionOfSickness(quarantineStatus)
+                            else -> HealthStatusData.NoHealthStatus
                         }
                     }
                     is QuarantineStatus.Free -> {

--- a/app/src/main/java/at/roteskreuz/stopcorona/utils/DateTimeExtensions.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/utils/DateTimeExtensions.kt
@@ -176,6 +176,20 @@ fun Long.asExposureInterval(): ZonedDateTime {
 }
 
 /**
+ * Checks the receiver if it is after [other]
+ *
+ * @param other
+ * @return [this] if the [this] is after [other], else [null]
+ */
+fun ZonedDateTime.afterOrNull(other: ZonedDateTime): ZonedDateTime? {
+    return if (isAfter(other)) {
+        this
+    } else {
+        null
+    }
+}
+
+/**
  * Returns start of the day of the provided [ZonedDateTime].
  */
 fun ZonedDateTime.startOfTheDay(): ZonedDateTime = truncatedTo(ChronoUnit.DAYS)
@@ -228,10 +242,12 @@ fun ZonedDateTime.areOnTheSameDay(otherDateTime: ZonedDateTime): Boolean {
 }
 
 /**
- * Evaluates if two dates are on the same calendar day in UTC
+ * Evaluates if two dates are on the same calendar day in UTC.
+ *
+ * Two null-Instances are considered to be on the same day.
  */
-fun Instant.areOnTheSameUtcDay(otherDateTime: Instant): Boolean {
-    return startOfTheUtcDay() == otherDateTime.startOfTheUtcDay()
+fun Instant?.areOnTheSameUtcDay(otherDateTime: Instant?): Boolean {
+    return this?.startOfTheUtcDay() == otherDateTime?.startOfTheUtcDay()
 }
 
 /**

--- a/app/src/main/java/at/roteskreuz/stopcorona/utils/DateTimeExtensions.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/utils/DateTimeExtensions.kt
@@ -11,12 +11,6 @@ import org.threeten.bp.temporal.ChronoUnit
 import timber.log.Timber
 import kotlin.math.abs
 
-/**
- * Extension related to date and time.
- */
-
-private val UTC_TIMEZONE: ZoneId
-    get() = ZoneId.of("UTC")
 
 /**
  * Get minutes difference between two times.
@@ -168,7 +162,7 @@ fun ZonedDateTime.toRollingStartIntervalNumber(): Int {
 fun Long.asExposureInterval(): ZonedDateTime {
     return ZonedDateTime.ofInstant(
         Instant.ofEpochSecond(this * Constants.ExposureNotification.INTERVAL_NUMBER_OFFSET.seconds),
-        UTC_TIMEZONE
+        ZoneOffset.UTC
     )
 }
 

--- a/app/src/main/java/at/roteskreuz/stopcorona/utils/DateTimeExtensions.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/utils/DateTimeExtensions.kt
@@ -9,8 +9,6 @@ import org.threeten.bp.*
 import org.threeten.bp.format.DateTimeFormatter
 import org.threeten.bp.temporal.ChronoUnit
 import timber.log.Timber
-import kotlin.math.abs
-
 
 /**
  * Get minutes difference between two times.
@@ -20,17 +18,28 @@ fun ZonedDateTime.minutesTo(other: ZonedDateTime): Long {
 }
 
 /**
- * Get duration between two times.
+ * Get milliseconds to other time.
+ *
+ * If other time is in the past return 0L
  */
-operator fun ZonedDateTime.minus(other: ZonedDateTime): Duration {
-    return Duration.between(this, other).abs()
+fun ZonedDateTime.millisTo(other: ZonedDateTime): Long {
+    return (other - this).toMillis().coerceAtLeast(0)
+}
+
+/**
+ * Get [Duration] to other time.
+ */
+infix operator fun ZonedDateTime.minus(other: ZonedDateTime): Duration {
+    return Duration.between(other, this)
 }
 
 /**
  * Get days difference between two dates.
+ *
+ * If other day is in the past return 0L
  */
 fun LocalDate.daysTo(other: LocalDate): Long {
-    return abs(this.toEpochDay() - other.toEpochDay())
+    return (other.toEpochDay() - this.toEpochDay()).coerceAtLeast(0)
 }
 
 /**
@@ -157,7 +166,7 @@ fun ZonedDateTime.toRollingStartIntervalNumber(): Int {
 }
 
 /**
- * Converts a interval number from exposure notification framework to the [ZonedDateTime].
+ * Converts an interval number from exposure notification framework to an [Instant].
  */
 fun Long.asExposureInterval(): ZonedDateTime {
     return ZonedDateTime.ofInstant(
@@ -239,6 +248,8 @@ fun Instant.plusDays(days: Long): Instant = plus(days, ChronoUnit.DAYS)
  */
 fun Instant.minusDays(days: Long): Instant = minus(days, ChronoUnit.DAYS)
 
-fun ZonedDateTime.millisUntilTheStartOfTheNextUtcDay(): Long {
-    return (this.plusDays(1).startOfTheUtcDay() - this).toMillis()
+fun ZonedDateTime.millisToNextUtcDay(): Long {
+    val nextDay = this.plusDays(1)
+    val startOfTheNextUtcDay = nextDay.startOfTheUtcDay()
+    return this.millisTo(startOfTheNextUtcDay)
 }

--- a/app/src/test/java/at/roteskreuz/stopcorona/model/repositories/QuarantineStatusTest.kt
+++ b/app/src/test/java/at/roteskreuz/stopcorona/model/repositories/QuarantineStatusTest.kt
@@ -1,36 +1,36 @@
 package at.roteskreuz.stopcorona.model.repositories
 
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.threeten.bp.ZonedDateTime
 
 /**
  * Assuming on the 22nd of June we´re quarantined for the next 7 days:
  * 22.06. - Tag 0 (der zählt nicht) -> noch 8 Tage
-   23.06. - Tag 1-> noch 7 Tage
-   24.06. - Tag 2-> noch 6 Tage
-   25.06. - Tag 3-> noch 5 Tage
-   26.06. - Tag 4-> noch 4 Tage
-   27.06. - Tag 5-> noch 3 Tage
-   28.06. - Tag 6 -> noch 2 Tage
-   29.06. - Tag 7 -> noch 1 Tag
+23.06. - Tag 1-> noch 7 Tage
+24.06. - Tag 2-> noch 6 Tage
+25.06. - Tag 3-> noch 5 Tage
+26.06. - Tag 4-> noch 4 Tage
+27.06. - Tag 5-> noch 3 Tage
+28.06. - Tag 6 -> noch 2 Tage
+29.06. - Tag 7 -> noch 1 Tag
  */
 class QuarantineStatusTest {
 
     @Test
-    fun `days until end of quarantine today needs to be 1`(){
+    fun `days until end of quarantine today needs to be 1`() {
         val endsToday = ZonedDateTime.now().plusHours(1)
-        val limited = QuarantineStatus.Jailed.Limited(end = endsToday, byContact = true)
+        val limited = QuarantineStatus.Jailed.Limited(end = endsToday, bySelfDiagnosis = null, byRedWarning = null, byYellowWarning = endsToday)
 
-        assertEquals(limited.daysUntilEnd(),1)
+        assertEquals(limited.daysUntilEnd(), 1)
     }
 
     @Test
-    fun `7 days of quarantine actually show as 8 days`(){
+    fun `7 days of quarantine actually show as 8 days`() {
         val endsToday = ZonedDateTime.now().plusDays(7)
-        val limited = QuarantineStatus.Jailed.Limited(end = endsToday, byContact = true)
+        val limited = QuarantineStatus.Jailed.Limited(end = endsToday, bySelfDiagnosis = null, byRedWarning = null, byYellowWarning = endsToday)
 
-        assertEquals(limited.daysUntilEnd(),8)
+        assertEquals(limited.daysUntilEnd(), 8)
     }
 }
 

--- a/app/src/test/java/at/roteskreuz/stopcorona/utils/DateTimeExtensionsKtTest.kt
+++ b/app/src/test/java/at/roteskreuz/stopcorona/utils/DateTimeExtensionsKtTest.kt
@@ -1,8 +1,7 @@
 package at.roteskreuz.stopcorona.utils
 
+import org.junit.Assert.assertEquals
 import org.junit.Test
-
-import org.junit.Assert.*
 import org.threeten.bp.ZoneId
 import org.threeten.bp.ZonedDateTime
 
@@ -18,7 +17,7 @@ class DateTimeExtensionsKtTest {
             .withSecond(0)
             .withNano(0)
         // 12 hours + 2 hours offset 
-        assertEquals((12+2)*60*60*1000,todayNoon.millisUntilTheStartOfTheNextUtcDay())
+        assertEquals((12 + 2) * 60 * 60 * 1000, todayNoon.millisToNextUtcDay())
 
     }
 }

--- a/app/src/test/java/at/roteskreuz/stopcorona/utils/ExposureNotficationExtensionsKtTest.kt
+++ b/app/src/test/java/at/roteskreuz/stopcorona/utils/ExposureNotficationExtensionsKtTest.kt
@@ -57,7 +57,7 @@ class ExposureNotficationExtensionsKtTest {
         val dates = listUnderTest.extractLatestRedAndYellowContactDate(THRESHOLD)
 
         assertNotNull(dates.firstYellowDay)
-        assertTrue(dates.firstYellowDay!!.areOnTheSameUtcDay(YESTERDAY))
+        assertTrue(dates.firstYellowDay.areOnTheSameUtcDay(YESTERDAY))
         assertNull(dates.firstRedDay)
     }
 
@@ -70,7 +70,7 @@ class ExposureNotficationExtensionsKtTest {
 
         assert(dates.firstYellowDay == null)
         assertNotNull(dates.firstRedDay)
-        assert(dates.firstRedDay!!.areOnTheSameUtcDay(YESTERDAY))
+        assert(dates.firstRedDay.areOnTheSameUtcDay(YESTERDAY))
     }
 
     @Test
@@ -84,7 +84,7 @@ class ExposureNotficationExtensionsKtTest {
 
             assert(dates.firstYellowDay == null)
             assertNotNull(dates.firstRedDay)
-            assert(dates.firstRedDay!!.areOnTheSameUtcDay(YESTERDAY))
+            assert(dates.firstRedDay.areOnTheSameUtcDay(YESTERDAY))
         }
     }
 }

--- a/core/src/main/java/at/roteskreuz/stopcorona/skeleton/core/model/api/converters/Rfc3339InstantAdapter.kt
+++ b/core/src/main/java/at/roteskreuz/stopcorona/skeleton/core/model/api/converters/Rfc3339InstantAdapter.kt
@@ -3,7 +3,7 @@ package at.roteskreuz.stopcorona.skeleton.core.model.api.converters
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.ToJson
 import org.threeten.bp.Instant
-import org.threeten.bp.ZoneId
+import org.threeten.bp.ZoneOffset
 import org.threeten.bp.ZonedDateTime
 import org.threeten.bp.format.DateTimeFormatter
 
@@ -23,7 +23,7 @@ object Rfc3339InstantAdapter {
     @ToJson
     fun toJson(value: Instant?): String? {
         return value?.let {
-            DateTimeFormatter.ISO_ZONED_DATE_TIME.format(ZonedDateTime.ofInstant(it, ZoneId.of("UTC")))
+            DateTimeFormatter.ISO_ZONED_DATE_TIME.format(ZonedDateTime.ofInstant(it, ZoneOffset.UTC))
         }
     }
 }

--- a/core/src/main/java/at/roteskreuz/stopcorona/skeleton/core/model/db/converters/DateTimeConverter.kt
+++ b/core/src/main/java/at/roteskreuz/stopcorona/skeleton/core/model/db/converters/DateTimeConverter.kt
@@ -1,10 +1,7 @@
 package at.roteskreuz.stopcorona.skeleton.core.model.db.converters
 
 import androidx.room.TypeConverter
-import org.threeten.bp.Instant
-import org.threeten.bp.LocalDate
-import org.threeten.bp.ZoneId
-import org.threeten.bp.ZonedDateTime
+import org.threeten.bp.*
 
 /**
  * Converter for dateTime using [Instant], [ZonedDateTime] or [LocalDate].
@@ -16,7 +13,7 @@ class DateTimeConverter {
         timestamp?.let { ZonedDateTime.ofInstant(Instant.ofEpochSecond(it), ZoneId.systemDefault()) }
 
     @TypeConverter
-    fun dateTimeToTimestamp(date: ZonedDateTime?): Long? = date?.withZoneSameInstant(ZoneId.of("UTC"))?.toEpochSecond()
+    fun dateTimeToTimestamp(date: ZonedDateTime?): Long? = date?.withZoneSameInstant(ZoneOffset.UTC)?.toEpochSecond()
 
     @TypeConverter
     fun timestampToInstant(timestamp: Long?): Instant? = timestamp?.let { Instant.ofEpochSecond(it) }


### PR DESCRIPTION
## Changes

- Do not report quarantine if quarantine end times are in the past.
- Also time calculation cleanup.
- Fix scheduling of background matching.

## Solved issues

- [CTAA_1120](https://tasks.pxp-x.com/browse/CTAA-1120)
