### PR TITLE
Fix/ctaa 1120 quarantine days after the time is elapsed it shows 1 days

### DIFF
--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/QuarantineRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/QuarantineRepository.kt
@@ -172,12 +172,13 @@ class QuarantineRepositoryImpl(
     override var dateOfFirstMedicalConfirmation: ZonedDateTime? by preferences.nullableZonedDateTimeSharedPreferencesProperty(
         PREF_DATE_OF_FIRST_MEDICAL_CONFIRMATION)
 
-    private val dateOfFirstMedicalConfirmationObservable = preferences.observeNullableZonedDateTime(PREF_DATE_OF_FIRST_MEDICAL_CONFIRMATION)
+    private val dateOfFirstMedicalConfirmationObservable =
+        preferences.observeNullableZonedDateTime(PREF_DATE_OF_FIRST_MEDICAL_CONFIRMATION).shareReplayLast()
 
     private var dateOfFirstSelfDiagnose: ZonedDateTime? by preferences.nullableZonedDateTimeSharedPreferencesProperty(
         PREF_DATE_OF_FIRST_SELF_DIAGNOSE)
 
-    private var dateOfFirstSelfDiagnoseObservable = preferences.observeNullableZonedDateTime(PREF_DATE_OF_FIRST_SELF_DIAGNOSE)
+    private var dateOfFirstSelfDiagnoseObservable = preferences.observeNullableZonedDateTime(PREF_DATE_OF_FIRST_SELF_DIAGNOSE).shareReplayLast()
 
     private var dateOfFirstSelfDiagnoseBackup: ZonedDateTime?
         by preferences.nullableZonedDateTimeSharedPreferencesProperty(PREF_DATE_OF_FIRST_SELF_DIAGNOSE_BACKUP)
@@ -185,7 +186,7 @@ class QuarantineRepositoryImpl(
     private var dateOfLastSelfDiagnose: ZonedDateTime?
         by preferences.nullableZonedDateTimeSharedPreferencesProperty(PREF_DATE_OF_LAST_SELF_DIAGNOSE)
 
-    private val dateOfLastSelfDiagnoseObservable = preferences.observeNullableZonedDateTime(PREF_DATE_OF_LAST_SELF_DIAGNOSE)
+    private val dateOfLastSelfDiagnoseObservable = preferences.observeNullableZonedDateTime(PREF_DATE_OF_LAST_SELF_DIAGNOSE).shareReplayLast()
 
     private var dateOfLastSelfDiagnoseBackup: ZonedDateTime?
         by preferences.nullableZonedDateTimeSharedPreferencesProperty(PREF_DATE_OF_LAST_SELF_DIAGNOSE_BACKUP)
@@ -195,31 +196,32 @@ class QuarantineRepositoryImpl(
             PREF_DATE_OF_LAST_RED_CONTACT
         )
 
-    private val dateOfLastRedContactObservable = preferences.observeNullableInstant(PREF_DATE_OF_LAST_RED_CONTACT)
+    private val dateOfLastRedContactObservable = preferences.observeNullableInstant(PREF_DATE_OF_LAST_RED_CONTACT).shareReplayLast()
 
     private var dateOfLastYellowContact: Instant?
         by preferences.nullableInstantSharedPreferencesProperty(
             PREF_DATE_OF_LAST_YELLOW_CONTACT
         )
 
-    private val dateOfLastYellowContactObservable = preferences.observeNullableInstant(PREF_DATE_OF_LAST_YELLOW_CONTACT)
+    private val dateOfLastYellowContactObservable = preferences.observeNullableInstant(PREF_DATE_OF_LAST_YELLOW_CONTACT).shareReplayLast()
 
     private var dateOfLastSelfMonitoringInstruction: ZonedDateTime?
         by preferences.nullableZonedDateTimeSharedPreferencesProperty(
             PREF_DATE_OF_LAST_SELF_MONITORING
         )
 
-    private val dateOfLastSelfMonitoringInstructionObservable = preferences.observeNullableZonedDateTime(PREF_DATE_OF_LAST_SELF_MONITORING)
+    private val dateOfLastSelfMonitoringInstructionObservable =
+        preferences.observeNullableZonedDateTime(PREF_DATE_OF_LAST_SELF_MONITORING).shareReplayLast()
 
     private var showQuarantineEnd: Boolean
         by preferences.booleanSharedPreferencesProperty(PREF_SHOW_QUARANTINE_END, false)
 
-    private val showQuarantineEndObservable = preferences.observeBoolean(PREF_SHOW_QUARANTINE_END, false)
+    private val showQuarantineEndObservable = preferences.observeBoolean(PREF_SHOW_QUARANTINE_END, false).shareReplayLast()
 
     private var missingKeysUploaded: Boolean
         by preferences.booleanSharedPreferencesProperty(PREF_MISSING_KEYS_UPLOADED, false)
 
-    private val missingKeysUploadedObservable = preferences.observeBoolean(PREF_MISSING_KEYS_UPLOADED, false)
+    private val missingKeysUploadedObservable = preferences.observeBoolean(PREF_MISSING_KEYS_UPLOADED, false).shareReplayLast()
 
     override val hasSelfDiagnoseBackup: Boolean
         get() = dateOfFirstSelfDiagnoseBackup != null && dateOfLastSelfDiagnoseBackup != null

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/QuarantineRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/QuarantineRepository.kt
@@ -229,7 +229,7 @@ class QuarantineRepositoryImpl(
     /**
      * Emit at the next time the quarantineState needs updating.
      */
-    private val quarantineStateNeedsTimeBasedUpdateEventSubject = TimerEventSubject()
+    private val quarantineStateNeedsTimeBasedUpdateEventSubject = TimerEventSubject().apply { startTicker() }
 
     private val quarantineStateObservable = Observables.combineLatest(
         configurationRepository.observeConfiguration(),

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/workers/EndQuarantineNotifierWorker.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/workers/EndQuarantineNotifierWorker.kt
@@ -3,7 +3,6 @@ package at.roteskreuz.stopcorona.model.workers
 import android.content.Context
 import androidx.work.*
 import at.roteskreuz.stopcorona.model.repositories.NotificationsRepository
-import at.roteskreuz.stopcorona.model.repositories.QuarantineRepository
 import at.roteskreuz.stopcorona.utils.millisTo
 import at.roteskreuz.stopcorona.utils.startOfTheDay
 import org.koin.standalone.KoinComponent
@@ -53,11 +52,8 @@ class EndQuarantineNotifierWorker(
     }
 
     private val notificationsRepository: NotificationsRepository by inject()
-    private val quarantineRepository: QuarantineRepository by inject()
 
     override suspend fun doWork(): Result {
-
-        quarantineRepository.setShowQuarantineEnd()
         notificationsRepository.displayEndQuarantineNotification()
 
         return Result.success()

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/workers/ExposureMatchingWorker.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/workers/ExposureMatchingWorker.kt
@@ -71,14 +71,15 @@ class ExposureMatchingWorker(
     private val diagnosisKeysRepository: DiagnosisKeysRepository by inject()
 
     override suspend fun doWork(): Result {
+        // Reschedule first thing in case we get killed later on
+        enqueueNextExposureMatching(workManager)
+
         try {
             diagnosisKeysRepository.fetchAndForwardNewDiagnosisKeysToTheExposureNotificationFramework()
         } catch (ex: Exception) {
             //we agreed to silently fail in case of errors here
             Timber.e(SilentError(ex))
         }
-        // Schedule the next exposure matching work.
-        enqueueNextExposureMatching(workManager)
         return Result.success()
     }
 }

--- a/app/src/main/java/at/roteskreuz/stopcorona/utils/NonNullableBehaviorSubject.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/utils/NonNullableBehaviorSubject.kt
@@ -8,7 +8,7 @@ import io.reactivex.subjects.Subject
 /**
  * Helper class with functionality same as [BehaviorSubject] with default non nullable value.
  */
-class NonNullableBehaviorSubject<T : Any>(defaultValue: T) : Subject<T>() {
+open class NonNullableBehaviorSubject<T : Any>(defaultValue: T) : Subject<T>() {
 
     private val behaviourSubject = BehaviorSubject.createDefault<T>(defaultValue)
 

--- a/app/src/main/java/at/roteskreuz/stopcorona/utils/TimerEventSubject.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/utils/TimerEventSubject.kt
@@ -1,0 +1,73 @@
+package at.roteskreuz.stopcorona.utils
+
+import at.roteskreuz.stopcorona.utils.TimerEventSubject.NextEventTime.Delay
+import at.roteskreuz.stopcorona.utils.TimerEventSubject.NextEventTime.Never
+import io.reactivex.Observable
+import org.threeten.bp.ZonedDateTime
+import java.util.concurrent.TimeUnit
+
+/**
+ * An Observable that will emit a [Unit] at a previousely set time.
+ *
+ * The next emission can be set at any time by calling [setNextEvent].
+ * A previousely scheduled event will be canceled if not already emitted.
+ */
+class TimerEventSubject : NonNullableBehaviorSubject<Unit>(Unit) {
+
+    private val nextEventTimeSubject = NonNullableBehaviorSubject<NextEventTime>(Never)
+
+    init {
+        /**
+         * Whenever [nextEventTimeSubject] emits a new event time, we want to reschedule emission.
+         */
+        nextEventTimeSubject.switchMap { nextEvent ->
+            when (nextEvent) {
+                Never -> {
+                    Observable.empty<Unit>()
+                }
+                is Delay -> {
+                    Observable.timer(nextEvent.delay, TimeUnit.MILLISECONDS).map { Unit }
+                }
+            }
+        }.subscribe(this)
+    }
+
+    /**
+     * Set time of next event.
+     *
+     * When [time] is in the past, the Observable will emit imediately.
+     * When [time] is null the observable will not emit at all.
+     * A previousely scheduled event will be canceled if not already emitted.
+     *
+     * @param time Time for next event. When [time] is null the observable will not emit at all.
+     */
+    fun setNextEvent(time: ZonedDateTime?) {
+        val delay = time?.let {
+            (time - ZonedDateTime.now()).toMillis()
+        }
+        setNextEvent(delay)
+    }
+
+    /**
+     * Set delay until next event.
+     *
+     * When [delay] is negative, the Observable will emit imediately.
+     * When [delay] is null the observable will not emit at all.
+     * A previousely scheduled event will be canceled if not already emitted.
+     *
+     * @param delay Delay until next event.
+     */
+    fun setNextEvent(delay: Long?) {
+        nextEventTimeSubject.onNext(
+            when {
+                delay != null -> Delay(delay.coerceAtLeast(0))
+                else -> Never
+            }
+        )
+    }
+
+    sealed class NextEventTime {
+        object Never : NextEventTime()
+        class Delay(val delay: Long) : NextEventTime()
+    }
+}

--- a/app/src/main/java/at/roteskreuz/stopcorona/utils/TimerEventSubject.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/utils/TimerEventSubject.kt
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit
  * An Observable that will emit a [Unit] at a previousely set time.
  *
  * TO make the observable start emitting, you first need to call [startTicker]:
- *  e.g. val timerEventSubject = TimerEventSubject().apply { disposables += start() }
+ *  e.g. val timerEventSubject = TimerEventSubject().apply { disposables += startTicker() }
  *
  * The next emission can be set at any time by calling [setNextEvent].
  * A previousely scheduled event will be canceled if not already emitted.


### PR DESCRIPTION
## Changes

- Fix missing updates if quarantines expire.
- Cache shared preferences observers
- Make sure the next exposure matching is always scheduled.

## Solved issues

- [CTAA_1120](https://tasks.pxp-x.com/browse/CTAA-11120)
