### PR TITLE
Fix Google Translate in de/strings.xml

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -219,7 +219,7 @@
 	<string name="certificate_report_status_button_extra">Jetzt IDs teilen</string>
 	<string name="certificate_report_status_invalid_tan_error">Die TAN ist nicht korrekt</string>
 	<string name="certificate_report_status_invalid_tan_error_description">Bitte prüfen Sie die TAN und geben Sie sie erneut ein.</string>
-	<string name="certificate_report_framework_is_not_ready_title">Der Belichtungsrahmen funktioniert nicht gut</string>
+	<string name="certificate_report_framework_is_not_ready_title">Das Exposure-Benachrichtigungsframework funktioniert nicht gut</string>
 	<string name="certificate_report_framework_is_not_ready_message">Das Exposure-Benachrichtigungsframework wird nicht ordnungsgemäß ausgeführt, um fortzufahren. Bitte gehen Sie zurück zum Dashboard und sehen Sie, was zur Behebung erforderlich ist.</string>
 	<string name="certificate_report_status_invalid_birth_date_error">Geburtsdatum ist ungültig</string>
 	<string name="certificate_report_status_invalid_birth_date_error_description">Bitte stellen Sie sicher, dass Sie Ihr Geburtsdatum im richtigen Format eingeben.</string>


### PR DESCRIPTION
## Changes

There was a typo in the german strings.xml - Not entirely sure what "not working well" is supposed to mean, but "Belichtungsrahmen" definitely is wrong.

Also: [Please don't use Google Translate for app translation](https://translate.google.com/#view=home&op=translate&sl=auto&tl=de&text=Exposure%20framework%20is%20not%20working%20well) :)

English base version:

https://github.com/austrianredcross/stopp-corona-android/blob/df6beddcb297114b4fbd4d8e17172f934ea59c61/app/src/main/res/values/strings.xml#L222
