### PR TITLE
Disable code obfuscation

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -67,17 +67,3 @@
 -keepclassmembers class **$WhenMappings {
     <fields>;
 }
-
-# Remove Kotlin bloat
--assumenosideeffects class kotlin.jvm.internal.Intrinsics {
-    static void checkParameterIsNotNull(java.lang.Object, java.lang.String);
-    static void checkNotNullParameter(java.lang.Object, java.lang.String);
-    static void checkFieldIsNotNull(java.lang.Object, java.lang.String);
-    static void checkFieldIsNotNull(java.lang.Object, java.lang.String, java.lang.String);
-    static void checkReturnedValueIsNotNull(java.lang.Object, java.lang.String);
-    static void checkReturnedValueIsNotNull(java.lang.Object, java.lang.String, java.lang.String);
-    static void checkNotNullExpressionValue(java.lang.Object, java.lang.String);
-    static void checkExpressionValueIsNotNull(java.lang.Object, java.lang.String);
-    static void checkNotNull(java.lang.Object);
-    static void checkNotNull(java.lang.Object, java.lang.String);
-}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -67,3 +67,17 @@
 -keepclassmembers class **$WhenMappings {
     <fields>;
 }
+
+# Remove Kotlin bloat
+-assumenosideeffects class kotlin.jvm.internal.Intrinsics {
+    static void checkParameterIsNotNull(java.lang.Object, java.lang.String);
+    static void checkNotNullParameter(java.lang.Object, java.lang.String);
+    static void checkFieldIsNotNull(java.lang.Object, java.lang.String);
+    static void checkFieldIsNotNull(java.lang.Object, java.lang.String, java.lang.String);
+    static void checkReturnedValueIsNotNull(java.lang.Object, java.lang.String);
+    static void checkReturnedValueIsNotNull(java.lang.Object, java.lang.String, java.lang.String);
+    static void checkNotNullExpressionValue(java.lang.Object, java.lang.String);
+    static void checkExpressionValueIsNotNull(java.lang.Object, java.lang.String);
+    static void checkNotNull(java.lang.Object);
+    static void checkNotNull(java.lang.Object, java.lang.String);
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -40,7 +40,8 @@
 
 #-printmapping ..\outputs\mapping.txt
 
--optimizationpasses 5
+-dontobfuscate
+
 -assumenosideeffects class android.util.Log {
     public static *** d(...);
     public static *** e(...);
@@ -61,7 +62,6 @@
 -keep class com.crashlytics.** { *; }
 -dontwarn com.crashlytics.**
 -keepattributes SourceFile,LineNumberTable
--keepnames class * extends java.lang.Throwable
 
 # Enums
 -keepclassmembers class **$WhenMappings {

--- a/core/proguard-rules.pro
+++ b/core/proguard-rules.pro
@@ -40,7 +40,6 @@
 
 #-printmapping ..\outputs\mapping.txt
 
--optimizationpasses 5
 -assumenosideeffects class android.util.Log {
     public static *** d(...);
     public static *** e(...);
@@ -87,15 +86,6 @@
     public static final *** NULL;
 }
 
--keepnames @com.google.android.gms.common.annotation.KeepName class *
--keepclassmembernames class * {
-    @com.google.android.gms.common.annotation.KeepName *;
-}
-
--keepnames class * implements android.os.Parcelable {
-    public static final ** CREATOR;
-}
-
 #retrofit
 -dontwarn retrofit2.**
 -keep class retrofit2.** { *; }
@@ -108,15 +98,6 @@
 
 #picasso
 -dontwarn com.squareup.picasso.OkHttpDownloader
-
-# ServiceLoader support
--keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}
--keepnames class kotlinx.coroutines.CoroutineExceptionHandler {}
-
-# Most of volatile fields are updated with AFU and should not be mangled
--keepclassmembernames class kotlinx.** {
-    volatile <fields>;
-}
 
 # Glide
 -keep public class * implements com.bumptech.glide.module.GlideModule


### PR DESCRIPTION
## Changes

Disable R8 code obfuscation, as it does not make much sense for OSS projects. Tree shaking and other optimizations are still enabled, just name mangling was removed. I also added a rule to get rid of all the Kotlin runtime-bloat.

Effects of this change:
||R8 time|APK size|Method count|
|---|---|---|---|
|Before|~49s|4.2 MB|22 694|
|After|~36s|4.3 MB|22 648|

As expected, the app size increased a little bit (~100 KB), but since the change is so small I think the gain in transparency is worth it.

## Solved issues

Closes #24 
