### PR TITLE
Task/ctaa 1701 adjust reporting algorythm to overlapping and part day te ks

### DIFF
--- a/app/schemas/at.roteskreuz.stopcorona.model.db.DefaultDatabase/24.json
+++ b/app/schemas/at.roteskreuz.stopcorona.model.db.DefaultDatabase/24.json
@@ -1,0 +1,661 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 24,
+    "identityHash": "d8d43703243555054a67f5e6f2e756db",
+    "entities": [
+      {
+        "tableName": "configuration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `warnBeforeSymptoms` INTEGER, `redWarningQuarantine` INTEGER, `yellowWarningQuarantine` INTEGER, `selfDiagnosedQuarantine` INTEGER, `uploadKeysDays` INTEGER, `cacheTime` INTEGER NOT NULL, `minimumRiskScore` INTEGER NOT NULL, `dailyRiskThreshold` INTEGER NOT NULL, `attenuationDurationThresholds` TEXT NOT NULL, `attenuationLevelValues` TEXT NOT NULL, `daysSinceLastExposureLevelValues` TEXT NOT NULL, `durationLevelValues` TEXT NOT NULL, `transmissionRiskLevelValues` TEXT NOT NULL, `scheduledProcessingIn5Min` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "warnBeforeSymptoms",
+            "columnName": "warnBeforeSymptoms",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "redWarningQuarantine",
+            "columnName": "redWarningQuarantine",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "yellowWarningQuarantine",
+            "columnName": "yellowWarningQuarantine",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "selfDiagnosedQuarantine",
+            "columnName": "selfDiagnosedQuarantine",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "uploadKeysDays",
+            "columnName": "uploadKeysDays",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cacheTime",
+            "columnName": "cacheTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minimumRiskScore",
+            "columnName": "minimumRiskScore",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dailyRiskThreshold",
+            "columnName": "dailyRiskThreshold",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attenuationDurationThresholds",
+            "columnName": "attenuationDurationThresholds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attenuationLevelValues",
+            "columnName": "attenuationLevelValues",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "daysSinceLastExposureLevelValues",
+            "columnName": "daysSinceLastExposureLevelValues",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationLevelValues",
+            "columnName": "durationLevelValues",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transmissionRiskLevelValues",
+            "columnName": "transmissionRiskLevelValues",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scheduledProcessingIn5Min",
+            "columnName": "scheduledProcessingIn5Min",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "configuration_questionnaire",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `configurationId` INTEGER NOT NULL, `language` INTEGER NOT NULL, `title` TEXT, `questionText` TEXT, FOREIGN KEY(`configurationId`) REFERENCES `configuration`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configurationId",
+            "columnName": "configurationId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "questionText",
+            "columnName": "questionText",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_configuration_questionnaire_configurationId",
+            "unique": false,
+            "columnNames": [
+              "configurationId"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_configuration_questionnaire_configurationId` ON `${TABLE_NAME}` (`configurationId`)"
+          },
+          {
+            "name": "index_configuration_questionnaire_language",
+            "unique": false,
+            "columnNames": [
+              "language"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_configuration_questionnaire_language` ON `${TABLE_NAME}` (`language`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "configuration",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "configurationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `currentToken` TEXT NOT NULL, `warningType` TEXT NOT NULL, `processingPhase` TEXT NOT NULL, `firstYellowDay` INTEGER, `created` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentToken",
+            "columnName": "currentToken",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "warningType",
+            "columnName": "warningType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "processingPhase",
+            "columnName": "processingPhase",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstYellowDay",
+            "columnName": "firstYellowDay",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_session_currentToken",
+            "unique": true,
+            "columnNames": [
+              "currentToken"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_session_currentToken` ON `${TABLE_NAME}` (`currentToken`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "full_batch",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` INTEGER NOT NULL, `batchNumber` INTEGER NOT NULL, `intervalStart` INTEGER NOT NULL, `fileName` TEXT NOT NULL, FOREIGN KEY(`sessionId`) REFERENCES `session`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "batchNumber",
+            "columnName": "batchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "intervalStart",
+            "columnName": "intervalStart",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_full_batch_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_full_batch_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "session",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "daily_batch",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` INTEGER NOT NULL, `batchNumber` INTEGER NOT NULL, `intervalStart` INTEGER NOT NULL, `fileName` TEXT NOT NULL, `processed` INTEGER NOT NULL, FOREIGN KEY(`sessionId`) REFERENCES `session`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "batchNumber",
+            "columnName": "batchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "intervalStart",
+            "columnName": "intervalStart",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "processed",
+            "columnName": "processed",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_daily_batch_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_daily_batch_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "session",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "configuration_questionnaire_answer",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`answerId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `questionnaireId` INTEGER NOT NULL, `text` TEXT, `decision` TEXT, FOREIGN KEY(`questionnaireId`) REFERENCES `configuration_questionnaire`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "answerId",
+            "columnName": "answerId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "questionnaireId",
+            "columnName": "questionnaireId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "decision",
+            "columnName": "decision",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "answerId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_configuration_questionnaire_answer_questionnaireId",
+            "unique": false,
+            "columnNames": [
+              "questionnaireId"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_configuration_questionnaire_answer_questionnaireId` ON `${TABLE_NAME}` (`questionnaireId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "configuration_questionnaire",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "questionnaireId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "page_content",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `configurationId` INTEGER NOT NULL, `language` INTEGER NOT NULL, `allClear_boldText` TEXT, `allClear_longText` TEXT, `allClear_roofLine` TEXT, `allClear_title` TEXT, `hint_boldText` TEXT, `hint_longText` TEXT, `hint_roofLine` TEXT, `hint_title` TEXT, `selfMonitoring_boldText` TEXT, `selfMonitoring_longText` TEXT, `selfMonitoring_roofLine` TEXT, `selfMonitoring_title` TEXT, `suspicion_boldText` TEXT, `suspicion_longText` TEXT, `suspicion_roofLine` TEXT, `suspicion_title` TEXT, FOREIGN KEY(`configurationId`) REFERENCES `configuration`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configurationId",
+            "columnName": "configurationId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "allClear.boldText",
+            "columnName": "allClear_boldText",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "allClear.longText",
+            "columnName": "allClear_longText",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "allClear.roofLine",
+            "columnName": "allClear_roofLine",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "allClear.title",
+            "columnName": "allClear_title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hint.boldText",
+            "columnName": "hint_boldText",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hint.longText",
+            "columnName": "hint_longText",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hint.roofLine",
+            "columnName": "hint_roofLine",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hint.title",
+            "columnName": "hint_title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "selfMonitoring.boldText",
+            "columnName": "selfMonitoring_boldText",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "selfMonitoring.longText",
+            "columnName": "selfMonitoring_longText",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "selfMonitoring.roofLine",
+            "columnName": "selfMonitoring_roofLine",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "selfMonitoring.title",
+            "columnName": "selfMonitoring_title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "suspicion.boldText",
+            "columnName": "suspicion_boldText",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "suspicion.longText",
+            "columnName": "suspicion_longText",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "suspicion.roofLine",
+            "columnName": "suspicion_roofLine",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "suspicion.title",
+            "columnName": "suspicion_title",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_page_content_configurationId",
+            "unique": false,
+            "columnNames": [
+              "configurationId"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_content_configurationId` ON `${TABLE_NAME}` (`configurationId`)"
+          },
+          {
+            "name": "index_page_content_language",
+            "unique": false,
+            "columnNames": [
+              "language"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_content_language` ON `${TABLE_NAME}` (`language`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "configuration",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "configurationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sent_temporary_exposure_keys",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rollingStartIntervalNumber` INTEGER NOT NULL, `_rollingPeriod` INTEGER NOT NULL, `password` TEXT NOT NULL, `messageType` TEXT NOT NULL, PRIMARY KEY(`rollingStartIntervalNumber`, `_rollingPeriod`))",
+        "fields": [
+          {
+            "fieldPath": "rollingStartIntervalNumber",
+            "columnName": "rollingStartIntervalNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "_rollingPeriod",
+            "columnName": "_rollingPeriod",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageType",
+            "columnName": "messageType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "rollingStartIntervalNumber",
+            "_rollingPeriod"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "scheduled_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`token` TEXT NOT NULL, PRIMARY KEY(`token`))",
+        "fields": [
+          {
+            "fieldPath": "token",
+            "columnName": "token",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "token"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd8d43703243555054a67f5e6f2e756db')"
+    ]
+  }
+}

--- a/app/src/main/java/at/roteskreuz/stopcorona/constants/Constants.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/constants/Constants.kt
@@ -80,9 +80,15 @@ object Constants {
         const val GOOGLE_PLAY_SERVICES_PACKAGE_NAME = GoogleApiAvailability.GOOGLE_PLAY_SERVICES_PACKAGE
 
         /**
-         * Framework expose new event each 10 minutes.
+         * Framework counts time in rolling periods of 10 minutes each.
          */
-        val INTERVAL_NUMBER_OFFSET: Duration = Duration.ofMinutes(10)
+        val ROLLING_PERIOD_DURATION: Duration = Duration.ofMinutes(10)
+
+        /**
+         * Number of rolling periods per day
+         */
+        val ROLLING_PERIODS_PER_DAY =
+            (Duration.ofDays(1).seconds / ROLLING_PERIOD_DURATION.seconds).toInt()
 
         /**
          * Local folder name for copy of exposure archives to be processed.

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/db/DefaultDatabase.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/db/DefaultDatabase.kt
@@ -407,21 +407,23 @@ abstract class DefaultDatabase : RoomDatabase() {
             migration(23, 24) {
                 // create new temp table with added _rollingPeriod and updated primary keys
                 execSQL(
-                    """CREATE TABLE IF NOT EXISTS `sent_temporary_exposure_keys_temp` (
-                      | `rollingStartIntervalNumber` INTEGER NOT NULL, 
-                      | `_rollingPeriod` INTEGER NOT NULL, 
-                      | `password` TEXT NOT NULL, 
-                      | `messageType` TEXT NOT NULL, 
-                      | PRIMARY KEY(`rollingStartIntervalNumber`, `_rollingPeriod`)
-                      |)
-                    """.trimMargin()
+                    """
+                    CREATE TABLE IF NOT EXISTS `sent_temporary_exposure_keys_temp` (
+                        `rollingStartIntervalNumber` INTEGER NOT NULL, 
+                        `_rollingPeriod` INTEGER NOT NULL, 
+                        `password` TEXT NOT NULL, 
+                        `messageType` TEXT NOT NULL, 
+                        PRIMARY KEY(`rollingStartIntervalNumber`, `_rollingPeriod`)
+                    )
+                    """
                 )
                 // copy data from old table to temp
                 execSQL(
-                    """INSERT INTO `sent_temporary_exposure_keys_temp` (`rollingStartIntervalNumber`, `_rollingPeriod`, `password`, `messageType`) 
-                      |SELECT `rollingStartIntervalNumber`, -1, `password`, `messageType` 
-                      |FROM `sent_temporary_exposure_keys`
-                    """.trimMargin()
+                    """
+                    INSERT INTO `sent_temporary_exposure_keys_temp` (`rollingStartIntervalNumber`, `_rollingPeriod`, `password`, `messageType`) 
+                        SELECT `rollingStartIntervalNumber`, -1, `password`, `messageType` 
+                        FROM `sent_temporary_exposure_keys`
+                    """
                 )
                 // delete old table
                 execSQL("DROP TABLE `sent_temporary_exposure_keys`")

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/db/dao/TemporaryExposureKeysDao.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/db/dao/TemporaryExposureKeysDao.kt
@@ -52,7 +52,7 @@ abstract class TemporaryExposureKeysDao {
     abstract suspend fun getSentTemporaryExposureKeys(): List<DbSentTemporaryExposureKeys>
 
     @Query("DELETE FROM sent_temporary_exposure_keys WHERE messageType = :messageType AND rollingStartIntervalNumber < :olderThan")
-    abstract suspend fun removeSentTemporarelyExposureKeysOlderThan(
+    abstract suspend fun removeSentTemporaryExposureKeysOlderThan(
         messageType: MessageType,
         olderThan: Int
     ): Int

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/db/dao/TemporaryExposureKeysDao.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/db/dao/TemporaryExposureKeysDao.kt
@@ -2,6 +2,7 @@ package at.roteskreuz.stopcorona.model.db.dao
 
 import androidx.room.*
 import at.roteskreuz.stopcorona.model.entities.exposure.DbSentTemporaryExposureKeys
+import at.roteskreuz.stopcorona.model.entities.exposure.UNDEFINED_ROLLING_PERIOD
 import at.roteskreuz.stopcorona.model.entities.infection.message.MessageType
 import at.roteskreuz.stopcorona.model.repositories.TekMetadata
 import io.reactivex.Flowable
@@ -12,11 +13,37 @@ import io.reactivex.Flowable
 @Dao
 abstract class TemporaryExposureKeysDao {
 
+    /**
+     * Delete key entries with given [DbSentTemporaryExposureKeys.rollingStartIntervalNumber] and missing [DbSentTemporaryExposureKeys.rollingPeriod]
+     */
+    @Query("DELETE from sent_temporary_exposure_keys WHERE rollingStartIntervalNumber in (:rollingStartIntervalNumbers) AND _rollingPeriod = -1")
+    protected abstract suspend fun removeOldPartialEntries(rollingStartIntervalNumbers: Collection<Int>): Int
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract suspend fun insertOrUpdateTemporaryExposureKey(record: DbSentTemporaryExposureKeys)
+    protected abstract suspend fun insertOrUpdateTemporaryExposureKeys(record: Collection<DbSentTemporaryExposureKeys>)
 
     @Query("SELECT * FROM sent_temporary_exposure_keys")
-    abstract fun observeSentTemporaryExposureKeys(): Flowable<List<DbSentTemporaryExposureKeys>>
+    protected abstract fun observeSentTemporaryExposureKeys(): Flowable<List<DbSentTemporaryExposureKeys>>
+
+    @Transaction
+    open suspend fun insertSentTemporaryExposureKeys(
+        exposureKeys: List<TekMetadata>
+    ) {
+        val coveredRollingStartIntervalNumbers = exposureKeys.map { exposureKeyWrapper ->
+            exposureKeyWrapper.validity.rollingStartIntervalNumber
+        }.distinct()
+        val sentTemporaryExposureKeys = exposureKeys.map { exposureKeyWrapper ->
+            DbSentTemporaryExposureKeys(
+                exposureKeyWrapper.validity.rollingStartIntervalNumber,
+                exposureKeyWrapper.validity.rollingPeriod ?: UNDEFINED_ROLLING_PERIOD,
+                exposureKeyWrapper.password,
+                exposureKeyWrapper.messageType
+            )
+        }
+        // Remove old partial entries as full entries will be creeated during the following insert
+        removeOldPartialEntries(coveredRollingStartIntervalNumbers)
+        insertOrUpdateTemporaryExposureKeys(sentTemporaryExposureKeys)
+    }
 
     @Query("SELECT * FROM sent_temporary_exposure_keys WHERE messageType = :messageType")
     abstract suspend fun getSentTemporaryExposureKeysByMessageType(messageType: MessageType): List<DbSentTemporaryExposureKeys>
@@ -24,24 +51,10 @@ abstract class TemporaryExposureKeysDao {
     @Query("SELECT * FROM sent_temporary_exposure_keys")
     abstract suspend fun getSentTemporaryExposureKeys(): List<DbSentTemporaryExposureKeys>
 
-    @Transaction
-    open suspend fun insertSentTemporaryExposureKeys(
-        exposureKeys: List<TekMetadata>
-    ) {
-        exposureKeys.forEach { exposureKeyWrapper ->
-            insertOrUpdateTemporaryExposureKey(
-                DbSentTemporaryExposureKeys(
-                    exposureKeyWrapper.rollingStartIntervalNumber,
-                    exposureKeyWrapper.password,
-                    exposureKeyWrapper.messageType
-                )
-            )
-        }
-    }
-
     @Query("DELETE FROM sent_temporary_exposure_keys WHERE messageType = :messageType AND rollingStartIntervalNumber < :olderThan")
     abstract suspend fun removeSentTemporarelyExposureKeysOlderThan(
         messageType: MessageType,
         olderThan: Int
-    )
+    ): Int
+
 }

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/entities/exposure/DbSentTemporaryExposureKeys.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/entities/exposure/DbSentTemporaryExposureKeys.kt
@@ -2,27 +2,34 @@ package at.roteskreuz.stopcorona.model.entities.exposure
 
 import android.os.Parcelable
 import androidx.room.Entity
-import androidx.room.PrimaryKey
+import androidx.room.Ignore
 import androidx.room.TypeConverter
 import at.roteskreuz.stopcorona.model.entities.infection.message.MessageType
 import at.roteskreuz.stopcorona.skeleton.core.model.entities.DbEntity
 import kotlinx.android.parcel.Parcelize
-import java.util.UUID
+import java.util.*
 
 /**
  * Describes a sent temporary exposure key through it's associated rolling start interval number
  * and password.
  */
+const val UNDEFINED_ROLLING_PERIOD = -1
+
 @Entity(
-    tableName = "sent_temporary_exposure_keys"
+    tableName = "sent_temporary_exposure_keys",
+    primaryKeys = ["rollingStartIntervalNumber", "_rollingPeriod"]
 )
 @Parcelize
 data class DbSentTemporaryExposureKeys(
-    @PrimaryKey
     val rollingStartIntervalNumber: Int,
+    val _rollingPeriod: Int,
     val password: UUID,
     val messageType: MessageType
-) : DbEntity, Parcelable
+) : DbEntity, Parcelable {
+    val rollingPeriod
+        @Ignore
+        get() = if (_rollingPeriod != UNDEFINED_ROLLING_PERIOD) _rollingPeriod else null
+}
 
 /**
  * Converter from and to UUID.

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/managers/DatabaseCleanupManager.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/managers/DatabaseCleanupManager.kt
@@ -52,7 +52,7 @@ class DatabaseCleanupManagerImpl(
             val thresholdRevokedMessagesAsRollingStart = ZonedDateTime.now()
                 .minusDays(NUMBER_OF_DAYS_THE_GREEN_KEYS_ARE_KEPT)
                 .toRollingStartIntervalNumber()
-            temporaryExposureKeysDao.removeSentTemporarelyExposureKeysOlderThan(
+            temporaryExposureKeysDao.removeSentTemporaryExposureKeysOlderThan(
                 MessageType.Revoke.Suspicion,
                 thresholdRevokedMessagesAsRollingStart
             )
@@ -66,7 +66,7 @@ class DatabaseCleanupManagerImpl(
                     .minusHours(yellowWarningQuarantine + 1)
                     .toRollingIntervalNumber()
 
-                temporaryExposureKeysDao.removeSentTemporarelyExposureKeysOlderThan(
+                temporaryExposureKeysDao.removeSentTemporaryExposureKeysOlderThan(
                     MessageType.InfectionLevel.Yellow,
                     thresholdYellowMessageAsRollingStart
                 )
@@ -81,7 +81,7 @@ class DatabaseCleanupManagerImpl(
                     .minusHours(redWarningQuarantine + 1)
                     .toRollingIntervalNumber()
 
-                temporaryExposureKeysDao.removeSentTemporarelyExposureKeysOlderThan(
+                temporaryExposureKeysDao.removeSentTemporaryExposureKeysOlderThan(
                     MessageType.InfectionLevel.Red,
                     thresholdRedMessagesAsRollingStart
                 )

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/managers/DatabaseCleanupManager.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/managers/DatabaseCleanupManager.kt
@@ -6,6 +6,7 @@ import at.roteskreuz.stopcorona.model.exceptions.SilentError
 import at.roteskreuz.stopcorona.model.repositories.ConfigurationRepository
 import at.roteskreuz.stopcorona.skeleton.core.model.helpers.AppDispatchers
 import at.roteskreuz.stopcorona.utils.startOfTheUtcDay
+import at.roteskreuz.stopcorona.utils.toRollingIntervalNumber
 import at.roteskreuz.stopcorona.utils.toRollingStartIntervalNumber
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -50,7 +51,6 @@ class DatabaseCleanupManagerImpl(
 
             val thresholdRevokedMessagesAsRollingStart = ZonedDateTime.now()
                 .minusDays(NUMBER_OF_DAYS_THE_GREEN_KEYS_ARE_KEPT)
-                .startOfTheUtcDay()
                 .toRollingStartIntervalNumber()
             temporaryExposureKeysDao.removeSentTemporarelyExposureKeysOlderThan(
                 MessageType.Revoke.Suspicion,
@@ -64,7 +64,7 @@ class DatabaseCleanupManagerImpl(
                     // +1 hour buffer time to avoid removing from midnight, since at this moment (12-Jun-2020)
                     // the rolling start interval is set by the framework at midnight (start of the day)
                     .minusHours(yellowWarningQuarantine + 1)
-                    .toRollingStartIntervalNumber()
+                    .toRollingIntervalNumber()
 
                 temporaryExposureKeysDao.removeSentTemporarelyExposureKeysOlderThan(
                     MessageType.InfectionLevel.Yellow,
@@ -79,7 +79,7 @@ class DatabaseCleanupManagerImpl(
                     // +1 hour buffer time to avoid removing from midnight, since at this moment (12-Jun-2020)
                     // the rolling start interval is set by the framework at midnight (start of the day)
                     .minusHours(redWarningQuarantine + 1)
-                    .toRollingStartIntervalNumber()
+                    .toRollingIntervalNumber()
 
                 temporaryExposureKeysDao.removeSentTemporarelyExposureKeysOlderThan(
                     MessageType.InfectionLevel.Red,

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/receivers/ExposureNotificationBroadcastReceiver.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/receivers/ExposureNotificationBroadcastReceiver.kt
@@ -39,8 +39,7 @@ class ExposureNotificationBroadcastReceiver : BroadcastReceiver(), KoinComponent
     private val workManager: WorkManager by inject()
 
     override fun onReceive(context: Context, intent: Intent) {
-        val action = intent.action
-        when (action) {
+        when (val action = intent.action) {
             ExposureNotificationClient.ACTION_EXPOSURE_STATE_UPDATED,
             ExposureNotificationClient.ACTION_EXPOSURE_NOT_FOUND -> {
                 val token = intent.getStringExtra(ExposureNotificationClient.EXTRA_TOKEN)

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/DiagnosisKeysRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/DiagnosisKeysRepository.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import org.threeten.bp.Instant
 import timber.log.Timber
-import java.util.UUID
+import java.util.*
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -435,7 +435,7 @@ class DiagnosisKeysRepositoryImpl(
  * Describes a temporary exposure key, it's associated random password and messageType.
  */
 data class TekMetadata(
-    val rollingStartIntervalNumber: Int,
+    val validity: Validity,
     val password: UUID,
     val messageType: MessageType
 )

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/ReportingRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/ReportingRepository.kt
@@ -2,6 +2,7 @@ package at.roteskreuz.stopcorona.model.repositories
 
 import at.roteskreuz.stopcorona.constants.Constants.Misc.EMPTY_STRING
 import at.roteskreuz.stopcorona.model.api.ApiInteractor
+import at.roteskreuz.stopcorona.model.entities.exposure.DbSentTemporaryExposureKeys
 import at.roteskreuz.stopcorona.model.entities.infection.info.ApiVerificationPayload
 import at.roteskreuz.stopcorona.model.entities.infection.info.WarningType
 import at.roteskreuz.stopcorona.model.entities.infection.info.asApiEntity
@@ -12,7 +13,7 @@ import at.roteskreuz.stopcorona.skeleton.core.model.helpers.AppDispatchers
 import at.roteskreuz.stopcorona.skeleton.core.model.scope.Scope
 import at.roteskreuz.stopcorona.utils.NonNullableBehaviorSubject
 import at.roteskreuz.stopcorona.utils.endOfTheUtcDay
-import at.roteskreuz.stopcorona.utils.startOfTheUtcDay
+import at.roteskreuz.stopcorona.utils.toRollingIntervalNumber
 import at.roteskreuz.stopcorona.utils.toRollingStartIntervalNumber
 import at.roteskreuz.stopcorona.utils.view.safeMap
 import com.google.android.gms.nearby.exposurenotification.TemporaryExposureKey
@@ -22,7 +23,7 @@ import io.reactivex.subjects.BehaviorSubject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.withContext
 import org.threeten.bp.ZonedDateTime
-import java.util.UUID
+import java.util.*
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -59,7 +60,7 @@ interface ReportingRepository {
      *
      * @return Returns the messageType the user sent to his contacts
      */
-    suspend fun uploadReportInformation(temporaryTracingKeys: List<TemporaryExposureKey>): MessageType
+    suspend fun uploadReportInformation(teks: List<TemporaryExposureKey>): MessageType
 
     /**
      * Set the validated personal data when a TAN was successfully requested.
@@ -170,9 +171,8 @@ class ReportingRepositoryImpl(
                 ?: throw InvalidConfigurationException.ConfigurationNotPresent
             val uploadKeysDays = configuration.uploadKeysDays
                 ?: throw InvalidConfigurationException.NullNumberOfDaysToUpload
-            val thresholdTimeFromConfiguration = ZonedDateTime.now()
+            val uploadStartIntervalNumberFromConfig = ZonedDateTime.now()
                 .minusDays(uploadKeysDays.toLong())
-                .startOfTheUtcDay()
                 .toRollingStartIntervalNumber()
 
             val dateWithMissingExposureKeys = dateWithMissingExposureKeys
@@ -180,8 +180,9 @@ class ReportingRepositoryImpl(
             if (dateWithMissingExposureKeys != null) {
                 // Report only the exposure keys that have not been uploaded in the day of the previous submission.
                 val keysToUpload = teks.filter {
-                    it.rollingStartIntervalNumber >= dateWithMissingExposureKeys.startOfTheUtcDay().toRollingStartIntervalNumber() &&
-                        it.rollingStartIntervalNumber <= dateWithMissingExposureKeys.endOfTheUtcDay().toRollingStartIntervalNumber()
+                    it.rollingStartIntervalNumber >= dateWithMissingExposureKeys.toRollingStartIntervalNumber() &&
+                            it.rollingStartIntervalNumber <= dateWithMissingExposureKeys.endOfTheUtcDay()
+                        .toRollingIntervalNumber()
                 }
 
                 uploadTeksWithMessageType(keysToUpload, infectionLevel)
@@ -189,18 +190,21 @@ class ReportingRepositoryImpl(
                 quarantineRepository.markMissingExposureKeysAsUploaded()
             } else {
                 // The regular flow of reporting the exposure keys.
-                val thresholdTime = if (infectionLevel == MessageType.InfectionLevel.Red) {
-                    diagnosisKeysRepository.getSentTeksByMessageType(
-                        MessageType.InfectionLevel.Yellow
-                    ).minBy { tekMetadata ->
-                        tekMetadata.rollingStartIntervalNumber
-                    }?.rollingStartIntervalNumber ?: thresholdTimeFromConfiguration
-                } else {
-                    thresholdTimeFromConfiguration
-                }
+                val uploadStartIntervalNumber =
+                    if (infectionLevel == MessageType.InfectionLevel.Red) {
+                        // If we sent a yellow warning before, send red warnings from the day of the
+                        // earliest yellow warning
+                        diagnosisKeysRepository.getSentTeksByMessageType(
+                            MessageType.InfectionLevel.Yellow
+                        ).map { tek ->
+                            tek.rollingStartIntervalNumber
+                        }.min() ?: uploadStartIntervalNumberFromConfig
+                    } else {
+                        uploadStartIntervalNumberFromConfig
+                    }
 
                 val teksToUpload = teks.filter {
-                    it.rollingStartIntervalNumber >= thresholdTime
+                    it.rollingStartIntervalNumber >= uploadStartIntervalNumber
                 }
                 uploadTeksWithMessageType(teksToUpload, infectionLevel)
 
@@ -230,18 +234,19 @@ class ReportingRepositoryImpl(
         teks: List<TemporaryExposureKey>,
         messageType: MessageType
     ) {
-        val passwordsByRollingStartInterval = diagnosisKeysRepository
+        val passwordsByValidity = diagnosisKeysRepository
             .getSentTemporaryExposureKeys()
             .associateBy(
-                keySelector = { it.rollingStartIntervalNumber },
+                keySelector = { it.validity },
                 valueTransform = { it.password }
             )
 
         val tekMetadata = teks.map { tek ->
-            val passwordForKey = passwordsByRollingStartInterval[tek.rollingStartIntervalNumber] ?: UUID.randomUUID()
+            val passwordForKey =
+                passwordsByValidity[tek.validity] ?: UUID.randomUUID()
 
             TekMetadata(
-                tek.rollingStartIntervalNumber,
+                tek.validity,
                 passwordForKey,
                 messageType
             )
@@ -272,14 +277,12 @@ class ReportingRepositoryImpl(
 
     private suspend fun uploadRevokeSuspicionInfo(teks: List<TemporaryExposureKey>): MessageType.Revoke.Suspicion {
         return withContext(coroutineContext) {
-            val rollingStartIntervalsToRevoke = diagnosisKeysRepository
-                .getSentTeksByMessageType(MessageType.InfectionLevel.Yellow)
-                .map {
-                    it.rollingStartIntervalNumber
-                }.toSet()
 
-            val teksToRevoke = teks.filter { it.rollingStartIntervalNumber in rollingStartIntervalsToRevoke }
-            uploadTeksWithMessageType(teksToRevoke, MessageType.GeneralRevoke)
+            uploadRevocationTeks(
+                teks = teks,
+                revoceWarningType = MessageType.InfectionLevel.Yellow,
+                targetWarningType = MessageType.GeneralRevoke
+            )
 
             quarantineRepository.revokePositiveSelfDiagnose(backup = false)
             quarantineRepository.markMissingExposureKeysAsNotUploaded()
@@ -290,23 +293,20 @@ class ReportingRepositoryImpl(
     private suspend fun uploadRevokeSicknessInfo(teks: List<TemporaryExposureKey>): MessageType.Revoke.Sickness {
         return withContext(coroutineContext) {
 
-            val updateStatus = when {
+            val targetWarningType = when {
                 quarantineRepository.hasSelfDiagnoseBackup -> MessageType.InfectionLevel.Yellow
                 else -> MessageType.GeneralRevoke
             }
 
-            val rollingStartIntervalsToRevoke = diagnosisKeysRepository
-                .getSentTeksByMessageType(MessageType.InfectionLevel.Red)
-                .map {
-                    it.rollingStartIntervalNumber
-                }.toSet()
-
-            val teksToRevoke = teks.filter { it.rollingStartIntervalNumber in rollingStartIntervalsToRevoke }
-            uploadTeksWithMessageType(teksToRevoke, updateStatus)
+            uploadRevocationTeks(
+                teks = teks,
+                revoceWarningType = MessageType.InfectionLevel.Red,
+                targetWarningType = targetWarningType
+            )
 
             quarantineRepository.revokeMedicalConfirmation()
 
-            when (updateStatus) {
+            when (targetWarningType) {
                 is MessageType.InfectionLevel.Yellow -> {
                     quarantineRepository.reportPositiveSelfDiagnoseFromBackup()
                 }
@@ -320,13 +320,29 @@ class ReportingRepositoryImpl(
         }
     }
 
+    private suspend fun uploadRevocationTeks(
+        teks: List<TemporaryExposureKey>,
+        revoceWarningType: MessageType.InfectionLevel,
+        targetWarningType: MessageType
+    ) {
+        val validityIntervallsToRevoke = diagnosisKeysRepository
+            .getSentTeksByMessageType(revoceWarningType)
+            .map {
+                it.validity
+            }.distinct()
+
+        val teksToRevoke =
+            teks.filter { it.validity in validityIntervallsToRevoke }
+        uploadTeksWithMessageType(teksToRevoke, targetWarningType)
+    }
+
     private fun List<TemporaryExposureKey>.pairWithPassword(
         tekMetadata: List<TekMetadata>
     ): List<Pair<TemporaryExposureKey, UUID>> {
-        val tekMetaDataByRollingStartIntervalNumber = tekMetadata.associateBy { it.rollingStartIntervalNumber }
+        val tekMetaDataByValidity = tekMetadata.associateBy { it.validity }
 
         return mapNotNull { tek ->
-            val matchingMetadata = tekMetaDataByRollingStartIntervalNumber[tek.rollingStartIntervalNumber]
+            val matchingMetadata = tekMetaDataByValidity[tek.validity]
             matchingMetadata?.let { tekMetadata ->
                 tek to tekMetadata.password
             }
@@ -406,6 +422,60 @@ data class PersonalData(
     val tanSuccessfullyRequested: Boolean = false
 )
 
+data class Validity(
+    val rollingStartIntervalNumber: Int,
+    val rollingPeriod: Int?
+) : Comparable<Validity> {
+
+    /**
+     * Order validity by end of the interval. If [rollingPeriod] is not set assume validity for the
+     * whole day.
+     *
+     * This is not formally correct but good enough for all use cases
+     */
+    override fun compareTo(other: Validity): Int {
+        val rollingEndIntervalNumber = rollingStartIntervalNumber + (rollingPeriod ?: 144)
+        val otherRollingEndIntervalNumber =
+            with(other) { rollingStartIntervalNumber + (rollingPeriod ?: 144) }
+
+        return rollingEndIntervalNumber.compareTo(otherRollingEndIntervalNumber)
+    }
+
+    /**
+     * Special equals operator which ignores the [rollingPeriod] if it is not available on either
+     * object.
+     *
+     * This is required for old keys in the database where the rolling period was not stored
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Validity) return false
+
+        if (rollingStartIntervalNumber != other.rollingStartIntervalNumber) return false
+        if (rollingPeriod == other.rollingPeriod) return true
+        // For old keys without a rolling period, ignore the rollingPeriod
+        if (rollingPeriod == null || other.rollingPeriod == null) return true
+
+        return false
+    }
+
+    /**
+     * Special hashCode which ignores the [rollingPeriod]. This leads to more collisions but is
+     * required due to the special [equals] operator.
+     *
+     * This is required for old keys in the database where the rolling period was not stored
+     */
+    override fun hashCode(): Int {
+        return rollingStartIntervalNumber
+    }
+}
+
+val TemporaryExposureKey.validity
+    get() = Validity(rollingStartIntervalNumber, rollingPeriod)
+
+val DbSentTemporaryExposureKeys.validity
+    get() = Validity(rollingStartIntervalNumber, rollingPeriod)
+
 /**
  * Automaton definition of the report sending process.
  */
@@ -446,5 +516,6 @@ sealed class InvalidConfigurationException(override val message: String) : Excep
     /**
      * No configuration present, not even the bundled config.
      */
-    object ConfigurationNotPresent : InvalidConfigurationException("No configuration present, not even the bundled config")
+    object ConfigurationNotPresent :
+        InvalidConfigurationException("No configuration present, not even the bundled config")
 }

--- a/app/src/main/java/at/roteskreuz/stopcorona/screens/debug/exposure_notifications/DebugExposureNotificationsViewModel.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/screens/debug/exposure_notifications/DebugExposureNotificationsViewModel.kt
@@ -156,7 +156,10 @@ class DebugExposureNotificationsViewModel(
     fun getTemporaryExposureKeyHistory() {
         exposureNotificationClient.temporaryExposureKeyHistory
             .addOnSuccessListener {
-                Timber.d("got the list of Temporary Exposure Keys $it")
+                Timber.d("got the list of Temporary Exposure Keys")
+                it.forEach {
+                    Timber.d("Key: ${it.rollingStartIntervalNumber}-${it.rollingPeriod}: $it")
+                }
                 exposureNotificationsTextSubject.onNext(
                     "got the list of TemporaryExposureKeys $it"
                 )

--- a/app/src/main/java/at/roteskreuz/stopcorona/utils/DateTimeExtensions.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/utils/DateTimeExtensions.kt
@@ -182,10 +182,18 @@ fun ZonedDateTime.isInTheFuture(): Boolean {
 }
 
 /**
- * Converts a unix timestamp to a rolling start interval number.
+ * Converts a unix timestamp to a rolling interval number.
+ */
+fun ZonedDateTime.toRollingIntervalNumber(): Int {
+    return (toInstant().epochSecond / Constants.ExposureNotification.INTERVAL_NUMBER_OFFSET.seconds).toInt()
+}
+
+/**
+ * Converts a unix timestamp to a rolling start interval number. I.e. the rolling interval number at
+ * the start of the day.
  */
 fun ZonedDateTime.toRollingStartIntervalNumber(): Int {
-    return (toInstant().epochSecond / Constants.ExposureNotification.INTERVAL_NUMBER_OFFSET.seconds).toInt()
+    return startOfTheUtcDay().toRollingIntervalNumber()
 }
 
 /**
@@ -202,7 +210,7 @@ fun Long.asExposureInterval(): ZonedDateTime {
  * Checks the receiver if it is after [other]
  *
  * @param other
- * @return [this] if the [this] is after [other], else [null]
+ * @return [this] if the [this] is after [other], else null
  */
 fun ZonedDateTime.afterOrNull(other: ZonedDateTime): ZonedDateTime? {
     return if (isAfter(other)) {

--- a/app/src/main/java/at/roteskreuz/stopcorona/utils/DateTimeExtensions.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/utils/DateTimeExtensions.kt
@@ -185,7 +185,7 @@ fun ZonedDateTime.isInTheFuture(): Boolean {
  * Converts a unix timestamp to a rolling interval number.
  */
 fun ZonedDateTime.toRollingIntervalNumber(): Int {
-    return (toInstant().epochSecond / Constants.ExposureNotification.INTERVAL_NUMBER_OFFSET.seconds).toInt()
+    return (toInstant().epochSecond / Constants.ExposureNotification.ROLLING_PERIOD_DURATION.seconds).toInt()
 }
 
 /**
@@ -201,7 +201,7 @@ fun ZonedDateTime.toRollingStartIntervalNumber(): Int {
  */
 fun Long.asExposureInterval(): ZonedDateTime {
     return ZonedDateTime.ofInstant(
-        Instant.ofEpochSecond(this * Constants.ExposureNotification.INTERVAL_NUMBER_OFFSET.seconds),
+        Instant.ofEpochSecond(this * Constants.ExposureNotification.ROLLING_PERIOD_DURATION.seconds),
         ZoneOffset.UTC
     )
 }


### PR DESCRIPTION
## Changes

- Use `rollingStartIntervalNumber` and `rollingPeriod` as composite key to the TEK passwords.
- Adjust reporting algorithm to the new composite key.
- Migration to new composite key.
- Fill in missing rollingPeriod on next update. Until then use same key for all TEKs of a day.

## Solved issues

- [Issue #1701](https://tasks.pxp-x.com/browse/CTAA-1701)
- [Issue #1715](https://tasks.pxp-x.com/browse/CTAA-1715)
