### PR TITLE
Make bluetooth repository to emit initial bluetooth enabled state if …

### DIFF
--- a/app/src/main/java/at/roteskreuz/stopcorona/di/RepositoryModule.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/di/RepositoryModule.kt
@@ -1,6 +1,7 @@
 package at.roteskreuz.stopcorona.di
 
 import android.bluetooth.BluetoothAdapter
+import at.roteskreuz.stopcorona.model.managers.BluetoothManager
 import at.roteskreuz.stopcorona.model.managers.ExposureNotificationManager
 import at.roteskreuz.stopcorona.model.managers.ExposureNotificationManagerImpl
 import at.roteskreuz.stopcorona.model.repositories.*
@@ -78,7 +79,7 @@ val repositoryModule = module {
     }
 
     single<BluetoothRepository> {
-        BluetoothRepositoryImpl(BluetoothAdapter.getDefaultAdapter())
+        BluetoothRepositoryImpl(BluetoothAdapter.getDefaultAdapter(), get<BluetoothManager>())
     }
 
     single<ExposureNotificationRepository> {

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/managers/BluetoothManager.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/managers/BluetoothManager.kt
@@ -1,7 +1,10 @@
 package at.roteskreuz.stopcorona.model.managers
 
 import at.roteskreuz.stopcorona.model.receivers.Registrable
+import at.roteskreuz.stopcorona.model.repositories.BluetoothRepository
 import at.roteskreuz.stopcorona.model.repositories.other.ContextInteractor
+import io.reactivex.subjects.PublishSubject
+import io.reactivex.subjects.Subject
 
 /**
  * Manager to start/stop listening for bluetooth enabled state.
@@ -17,6 +20,11 @@ interface BluetoothManager {
      * Stop listening for bluetooth changes.
      */
     fun stopListeningForChanges()
+
+    /**
+     * listening subject if bluetooth manager is starting to listen to bluetooth enabled changes
+     */
+    val listeningSubject : Subject<Boolean>
 }
 
 class BluetoothManagerImpl(
@@ -26,13 +34,17 @@ class BluetoothManagerImpl(
 
     override fun startListeningForChanges() {
         bluetoothStateReceiver.register(contextInteractor.applicationContext)
+        listeningSubject.onNext(true)
     }
 
     override fun stopListeningForChanges() {
         try {
             bluetoothStateReceiver.unregister(contextInteractor.applicationContext)
+            listeningSubject.onNext(false)
         } catch (e: Exception) {
             // ignored, receiver is probably not registered yet
         }
     }
+
+    override val listeningSubject: Subject<Boolean> = PublishSubject.create()
 }

--- a/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/BluetoothRepository.kt
+++ b/app/src/main/java/at/roteskreuz/stopcorona/model/repositories/BluetoothRepository.kt
@@ -1,9 +1,11 @@
 package at.roteskreuz.stopcorona.model.repositories
 
+import android.annotation.SuppressLint
 import android.bluetooth.BluetoothAdapter
 import at.roteskreuz.stopcorona.model.managers.BluetoothManager
 import at.roteskreuz.stopcorona.utils.NonNullableBehaviorSubject
 import io.reactivex.Observable
+import io.reactivex.schedulers.Schedulers
 
 /**
  * Wrapper for Bluetooth related functionality.
@@ -32,9 +34,21 @@ interface BluetoothRepository {
     fun updateEnabledState(enabled: Boolean)
 }
 
+@SuppressLint("CheckResult")
 class BluetoothRepositoryImpl(
-    private val bluetoothAdapter: BluetoothAdapter?
+    private val bluetoothAdapter: BluetoothAdapter?,
+    bluetoothManager: BluetoothManager
 ) : BluetoothRepository {
+
+    init {
+        bluetoothManager.listeningSubject
+            .subscribeOn(Schedulers.single())
+            .observeOn(Schedulers.single())
+            .filter { it }
+            .subscribe {
+                enabledStateSubject.onNext(bluetoothEnabled)
+            }
+    }
 
     private val enabledStateSubject = NonNullableBehaviorSubject(
         bluetoothAdapter?.isEnabled == true


### PR DESCRIPTION
## Issue

On some devices like Nexus 5X or Huawei P40, when the COVID framework switch is turned on when bluetooth was disabled, the activation of bluetooth doesn't get recognised. Cause is that initial state is not emitted if bluetooth manager starts listening to bluetooth changes and at the time if bluetooth manager starts listening and bluetooth is already enabled, the UI never realises the change.

## Changes

Make bluetooth repository to emit initial bluetooth enabled state if bluetooth manager is starting to listen to enabled changes.
